### PR TITLE
Identify beacons by 0x2080 service data; battery, rate colors, UI rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ Android APK and an iOS static library.
 
 ## Features
 
-- **KKM-only scanning**: scans unfiltered and gates results on KKM's
-  `BC:57:29` MAC prefix (name-derived on iOS), so only KBeacon
-  hardware shows up; deduplicates by address and drops beacons below
-  a configurable RSSI threshold (proximity limit, default -50 dBm).
-  A hardware `0x2080` service-UUID filter does not work: real
-  KBeacons advertise that UUID only as service data, which Android's
-  `ScanFilter.setServiceUuid` never matches.
+- **KKM-only scanning**: scans unfiltered and identifies KBeacons by
+  their `0x2080` service data, the same signal KKM's own library
+  uses, with KKM's `BC:57:29` MAC prefix and the factory name as
+  fallbacks for payload-less frames; deduplicates by address and
+  drops beacons below a configurable RSSI threshold (proximity
+  limit, default -50 dBm). A hardware `0x2080` service-UUID filter
+  does not work: real KBeacons advertise that UUID only as service
+  data, which Android's `ScanFilter.setServiceUuid` never matches.
+- **Live rows**: every listed beacon shows RSSI, the battery percent
+  broadcast in its service data (no connection needed), and its
+  measured advertisement interval, colored green when it matches the
+  expected interval input and red when it deviates.
+- **One-time permission page**: the app opens on a permission page
+  and moves to the scanner once bluetooth-scan and location are
+  granted; Start Scan refuses with a clear status while the
+  bluetooth adapter is off.
 - **Configuration over GATT**: full KBeacon config protocol
   (`src/KBeacon/Protocol.hs`, reverse engineered from KKM's
   [android_kbeaconlib2](https://github.com/kkmhogen/android_kbeaconlib2)):
@@ -29,7 +38,6 @@ Android APK and an iOS static library.
   beacon's outcome is POSTed as JSON (name, mac, applied period,
   battery percent with a warning flag under 98%, or the failure
   reason).
-- **Battery percent** per beacon, read from the config over GATT.
 
 ## Usage
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,29 +2,13 @@
 
 Everything the original Kotlin tool did is ported: beacon
 configuration over GATT, HTTP result reporting, battery percent and
-the KKM-only scan (a software identity gate on KKM's MAC prefix, see
-`identifyScanResult`) all landed with the hatter GATT API (hatter
-#108). What remains:
+the KKM-only scan (identity from the 0x2080 service data with MAC
+prefix and name fallbacks, see `identifyScanResult`) all landed with
+the hatter GATT (hatter #108) and advertisement-payload (hatter #238)
+APIs, which also brought battery-at-scan and renamed-beacon support
+on iOS. What remains:
 
-## 1. Renamed beacons on iOS
-
-KBeacon auth is keyed on the device MAC, which iOS never exposes.
-Factory-named beacons work (the MAC is reconstructed from KKM's OUI
-plus the "KBPro-XXXXXX" name suffix); renamed ones need the MAC from
-the advertisement's system packet or 0x2080 service data, which
-hatter's `BleScanResult` does not carry. Needs a hatter scan-result
-extension exposing raw advertisement payloads (follow-up to
-https://github.com/jappeace/hatter/issues/108).
-
-## 2. Advertisement-level battery percent
-
-Battery is currently read over GATT (`"btPt"` in the config JSON),
-which requires connecting. KBeacons also broadcast it in byte 0 of the
-0x2080 service data, which would show battery for beacons that are
-merely scanned; blocked on the same raw-advertisement hatter extension
-as item 1.
-
-## 3. Non-default passwords
+## 1. Non-default passwords
 
 The tool authenticates with KKM's factory password (sixteen zeros),
 like the original Kotlin implementation. Beacons with a changed
@@ -32,7 +16,7 @@ password need a password input field wired through to
 `KBeacon.Configure` (the protocol layer already takes the password as
 a parameter).
 
-## 4. Stall watchdog
+## 2. Stall watchdog
 
 Hatter apps run on the non-threaded GHC RTS, so the configure state
 machine cannot arm Haskell-side timeouts (see the Decision comment in

--- a/kbeacon-ota.cabal
+++ b/kbeacon-ota.cabal
@@ -58,3 +58,4 @@ test-suite unit
     , tasty      < 2
     , tasty-hunit < 1
     , text       < 3
+    , time

--- a/kbeacon-ota.cabal
+++ b/kbeacon-ota.cabal
@@ -34,6 +34,7 @@ library
     , text       < 3
     , time
     , unwitch    >= 3.0.0 && < 4
+    , uuid-types >= 1.0.4 && < 2
 
 executable kbeacon-ota
   import:        common-options

--- a/nix/consumer-cabal2nix.nix
+++ b/nix/consumer-cabal2nix.nix
@@ -13,11 +13,11 @@ mkDerivation {
   version = "0.2.0.0";
   # Decision: unwitch is deliberately absent even though the library
   # uses it. hatter's cross-deps.nix and ios-deps.nix always add
-  # unwitch to the collected package DB (hatterOwnDeps), and listing
-  # it here as well makes collect-deps copy the same .conf twice,
-  # which fails on the read-only first copy. The alternative, fixing
-  # collect-deps to deduplicate, lives in hatter, not here. The cabal
-  # file still declares unwitch for the native build.
+  # unwitch to the collected package DB (hatterOwnDeps), so listing
+  # it here would be redundant (collect-deps deduplicates .confs
+  # since the hatter pin at jappeace/hatter#239, so it would no
+  # longer fail, but there is nothing to gain). The cabal file still
+  # declares unwitch for the native build.
   libraryHaskellDepends = [
     base bytestring containers cryptohash-md5 text time
   ];

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/ble-advertisement-payloads",
       "submodules": false,
-      "revision": "119e58cc4b50ad1be3f801efdac4d300f25d72c4",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/119e58cc4b50ad1be3f801efdac4d300f25d72c4.tar.gz",
-      "hash": "sha256-O6534XCfuTYXkoOfn45JVA139IY74xVoHe+psFIVcPY="
+      "revision": "079dadfcfa0ff5b980e534f0765eec0d4dcb6b98",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/079dadfcfa0ff5b980e534f0765eec0d4dcb6b98.tar.gz",
+      "hash": "sha256-2we91fNLvzz2mL01zFraa5PXy/IN7vnJor/4CchPIyk="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/ble-advertisement-payloads",
       "submodules": false,
-      "revision": "7b6199a37acb6f7566d675d55a9781f9866bfbb8",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/7b6199a37acb6f7566d675d55a9781f9866bfbb8.tar.gz",
-      "hash": "sha256-Wu+cIol4roho27120P7wwcUO2zdMoaRMK6VUTbZuzEQ="
+      "revision": "119e58cc4b50ad1be3f801efdac4d300f25d72c4",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/119e58cc4b50ad1be3f801efdac4d300f25d72c4.tar.gz",
+      "hash": "sha256-O6534XCfuTYXkoOfn45JVA139IY74xVoHe+psFIVcPY="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,13 +4,13 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace-sloth",
+        "owner": "jappeace",
         "repo": "hatter"
       },
-      "branch": "feat/ble-advertisement-payloads",
+      "branch": "master",
       "submodules": false,
-      "revision": "079dadfcfa0ff5b980e534f0765eec0d4dcb6b98",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/079dadfcfa0ff5b980e534f0765eec0d4dcb6b98.tar.gz",
+      "revision": "b08827fc90da85eea3f5a3efd7ec85cf1a36d395",
+      "url": "https://github.com/jappeace/hatter/archive/b08827fc90da85eea3f5a3efd7ec85cf1a36d395.tar.gz",
       "hash": "sha256-2we91fNLvzz2mL01zFraa5PXy/IN7vnJor/4CchPIyk="
     },
     "mobile-core-tools": {

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,14 +4,14 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace",
+        "owner": "jappeace-sloth",
         "repo": "hatter"
       },
-      "branch": "master",
+      "branch": "feat/ble-advertisement-payloads",
       "submodules": false,
-      "revision": "f8ad26a3fd45b00622d2800e37a60932efd6283a",
-      "url": "https://github.com/jappeace/hatter/archive/f8ad26a3fd45b00622d2800e37a60932efd6283a.tar.gz",
-      "hash": "sha256-0tKVOQYghS/stgv8U/Xz+bX+dIAjv0Z8bhH+LiMswEQ="
+      "revision": "7b6199a37acb6f7566d675d55a9781f9866bfbb8",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/7b6199a37acb6f7566d675d55a9781f9866bfbb8.tar.gz",
+      "hash": "sha256-Wu+cIol4roho27120P7wwcUO2zdMoaRMK6VUTbZuzEQ="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -730,8 +730,9 @@ data RateVerdict
 rateVerdict :: Either Text AdvPeriodMs -> Maybe Int -> RateVerdict
 rateVerdict expected measured =
   case (expected, measured) of
-    (Left _, _) -> RateUnknown
-    (_, Nothing) -> RateUnknown
+    (Left _, Nothing) -> RateUnknown
+    (Left _, Just _) -> RateUnknown
+    (Right _, Nothing) -> RateUnknown
     (Right expectedPeriod, Just measuredMs) ->
       if abs (measuredMs - unAdvPeriodMs expectedPeriod) * 4
            <= unAdvPeriodMs expectedPeriod

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -127,7 +127,7 @@ import KBeacon.Protocol
   , defaultBeaconPassword
   , identifyScanResult
   , kkmExtDataBattery
-  , kkmExtDataServiceUuidText
+  , kkmExtDataServiceUuid
   , unAdvPeriodMs
   , unBeaconMac
   , validateAdvPeriod
@@ -419,7 +419,7 @@ scanResultExtData :: BleScanResult -> Maybe ByteString
 scanResultExtData result = case bsrAdvertisement result of
   Left _ -> Nothing
   Right advertisement ->
-    serviceDataForUuid kkmExtDataServiceUuidText advertisement
+    serviceDataForUuid kkmExtDataServiceUuid advertisement
 
 -- | Refresh a listed beacon from a repeated advertisement: RSSI and
 -- battery update, and the advertisement interval is measured from

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -5,11 +5,16 @@
 -- write a new advertisement interval to each of them, optionally
 -- reporting every result to an HTTP endpoint.
 --
--- The scan runs unfiltered and selects KKM beacons by their MAC
--- identity (see 'identifyScanResult' for why a hardware filter is not
--- usable), drops beacons below a configurable RSSI threshold (the
--- "proximity" idea of the original Kotlin tool) and deduplicates by
--- address. Configure All then walks the discovered list with
+-- The app opens on a permission page; once both runtime permissions
+-- are granted it moves to the scanner page and the permission UI is
+-- gone. The scan runs unfiltered and identifies KKM beacons by their
+-- 0x2080 service data (with MAC-prefix and factory-name fallbacks,
+-- see 'identifyScanResult'), drops beacons below a configurable RSSI
+-- threshold (the "proximity" idea of the original Kotlin tool) and
+-- deduplicates by address. Repeated advertisements refresh a listed
+-- beacon's RSSI and battery and measure its actual advertisement
+-- interval, which colors the row green or red against the expected
+-- interval input. Configure All then walks the discovered list with
 -- "KBeacon.Configure".
 --
 -- Action creation order matters: hatter's iOS simulator harness
@@ -18,24 +23,32 @@
 --
 -- Decision: the app lives in the library instead of the executable so
 -- the test suite can drive the exact functions the platform calls:
--- 'onScanResult' is the registered scan callback and 'appView' the
--- registered view builder, and the signal-to-UI integration test
--- feeds one and inspects the other. @app/Main.hs@ only re-exports
--- 'otaAppMain'.
+-- 'onScanResultAt' is the registered scan callback (with the clock
+-- injected) and 'appView' the registered view builder, and the
+-- signal-to-UI integration tests feed one and inspect the other.
+-- @app/Main.hs@ only re-exports 'otaAppMain'.
 module KBeacon.OtaApp
   ( -- * Entry point
     otaAppMain
     -- * App state
   , AppState(..)
+  , AppPage(..)
   , DiscoveredBeacon(..)
   , BeaconStatus(..)
   , newAppState
   , defaultRssiThreshold
     -- * Platform callbacks (drivable from tests)
   , onScanResult
+  , onScanResultAt
   , appView
+    -- * Pure decision helpers
+  , continuePastPermissions
+  , scanRefusalForAdapter
+  , RateVerdict(..)
+  , rateVerdict
   ) where
 
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as ByteString
 import Data.Char (intToDigit, toUpper)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
@@ -45,6 +58,7 @@ import Data.Text (Text, pack)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
 import Data.Text.Read qualified as TextRead
+import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 import Data.Word (Word8)
 import Foreign.Ptr (Ptr)
 import Hatter
@@ -63,9 +77,11 @@ import Hatter
 import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Ble
   ( BleScanResult(..)
+  , BleAdapterStatus(..)
   , BleDeviceAddress(..)
   , BleState
   , checkBleAdapter
+  , serviceDataForUuid
   , startBleScan
   , stopBleScan
   )
@@ -78,16 +94,24 @@ import Hatter.Http
   , hrStatusCode
   , performRequest
   )
-import Hatter.Permission (PermissionState, Permission(..), requestPermission)
+import Hatter.Permission
+  ( PermissionState
+  , Permission(..)
+  , PermissionStatus(..)
+  , requestPermission
+  )
 import Hatter.Widget
-  ( InputType(..)
+  ( Color(..)
+  , InputType(..)
   , TextInputConfig(..)
   , Widget(..)
   , column
+  , defaultStyle
   , row
   , scrollColumn
   , text
   , button
+  , wsTextColor
   )
 import KBeacon.Configure
   ( BeaconOutcome(..)
@@ -102,16 +126,34 @@ import KBeacon.Protocol
   , ScanIdentity(..)
   , defaultBeaconPassword
   , identifyScanResult
+  , kkmExtDataBattery
+  , kkmExtDataServiceUuidText
   , unAdvPeriodMs
   , unBeaconMac
   , validateAdvPeriod
   )
 import Unwitch.Convert.Word8 qualified as Word8
 
+-- | Which page the app shows. Permissions are dealt with once, on
+-- their own page; after that only the scanner is on screen.
+data AppPage
+  = PermissionPage
+  | ScannerPage
+  deriving (Show, Eq)
+
 -- | One beacon in the UI list.
 data DiscoveredBeacon = DiscoveredBeacon
   { beaconTarget :: BeaconTarget
   , beaconRssi :: Int
+  , beaconBattery :: Maybe Int
+    -- ^ Battery percent broadcast in the 0x2080 service data, when
+    -- the advertisement carried one.
+  , beaconLastSeenAt :: POSIXTime
+    -- ^ Arrival time of the latest advertisement, feeding the
+    -- interval measurement.
+  , beaconIntervalMs :: Maybe Int
+    -- ^ Measured advertisement interval (smoothed), Nothing until a
+    -- second advertisement arrives.
   , beaconStatus :: BeaconStatus
   , beaconReportNote :: Maybe Text
     -- ^ Outcome of the HTTP report for this beacon, when reporting is
@@ -120,7 +162,7 @@ data DiscoveredBeacon = DiscoveredBeacon
 
 -- | Lifecycle of a listed beacon.
 data BeaconStatus
-  = StatusDiscovered
+  = StatusFound
   | StatusConfiguring
   | StatusConfigured BeaconSuccess
   | StatusFailed Text
@@ -128,7 +170,8 @@ data BeaconStatus
 -- | All mutable app state, so the view function and the callbacks
 -- share one handle.
 data AppState = AppState
-  { stateBeacons :: IORef [DiscoveredBeacon]
+  { statePage :: IORef AppPage
+  , stateBeacons :: IORef [DiscoveredBeacon]
   , stateSeenAddresses :: IORef (Set Text)
   , stateAdvPeriodInput :: IORef Text
   , stateThresholdInput :: IORef Text
@@ -191,6 +234,7 @@ otaAppMain = do
 -- | Allocate the app state with its defaults.
 newAppState :: IO AppState
 newAppState = do
+  page <- newIORef PermissionPage
   beacons <- newIORef []
   seen <- newIORef Set.empty
   advPeriod <- newIORef "1000"
@@ -204,7 +248,8 @@ newAppState = do
   http <- newIORef Nothing
   redraw <- newIORef (pure ())
   pure AppState
-    { stateBeacons = beacons
+    { statePage = page
+    , stateBeacons = beacons
     , stateSeenAddresses = seen
     , stateAdvPeriodInput = advPeriod
     , stateThresholdInput = threshold
@@ -237,7 +282,8 @@ checkAdapterAction appState = do
   status <- checkBleAdapter
   setStatus appState ("BLE adapter: " <> pack (show status))
 
--- | Request the BLE permission set hatter exposes from Haskell.
+-- | Request the BLE permission set hatter exposes from Haskell, then
+-- leave the permission page when both are granted.
 -- BLUETOOTH_CONNECT (needed by connectGatt on API 31 and later) is
 -- not reachable through Hatter.Permission; MainActivity.onCreate
 -- requests it natively at startup.
@@ -249,25 +295,56 @@ requestPermissionsAction appState = do
     Just permissionState ->
       requestPermission permissionState PermissionBluetooth $ \bluetoothStatus -> do
         platformLog ("BLUETOOTH_SCAN permission: " <> pack (show bluetoothStatus))
-        requestPermission permissionState PermissionLocation $ \locationStatus ->
+        requestPermission permissionState PermissionLocation $ \locationStatus -> do
           platformLog ("ACCESS_FINE_LOCATION permission: " <> pack (show locationStatus))
+          continuePastPermissions appState bluetoothStatus locationStatus
 
--- | Start the unfiltered scan; 'onScanResult' gates on KKM identity,
--- the RSSI threshold and dedup.
+-- | Move to the scanner page when both permissions are granted; a
+-- denied permission keeps the permission page up with a status
+-- saying which one is missing.
+continuePastPermissions :: AppState -> PermissionStatus -> PermissionStatus -> IO ()
+continuePastPermissions appState bluetoothStatus locationStatus =
+  case (bluetoothStatus, locationStatus) of
+    (PermissionGranted, PermissionGranted) -> do
+      writeIORef (statePage appState) ScannerPage
+      setStatus appState "permissions granted"
+    (PermissionDenied, PermissionDenied) ->
+      setStatus appState "bluetooth scan and location permissions denied"
+    (PermissionDenied, PermissionGranted) ->
+      setStatus appState "bluetooth scan permission denied"
+    (PermissionGranted, PermissionDenied) ->
+      setStatus appState "location permission denied"
+
+-- | Why a scan cannot start given this adapter state; only an
+-- adapter that reports on can scan.
+scanRefusalForAdapter :: BleAdapterStatus -> Maybe Text
+scanRefusalForAdapter status = case status of
+  BleAdapterOn -> Nothing
+  BleAdapterOff -> Just "bluetooth is off, turn it on to scan"
+  BleAdapterUnauthorized -> Just "bluetooth permission missing, cannot scan"
+  BleAdapterUnsupported -> Just "this device does not support bluetooth LE"
+
+-- | Start the unfiltered scan after checking the adapter;
+-- 'onScanResultAt' gates on KKM identity, the RSSI threshold and
+-- dedup.
 startScanAction :: AppState -> IO ()
 startScanAction appState = do
-  mBleState <- readIORef (stateBle appState)
-  thresholdText <- readIORef (stateThresholdInput appState)
-  case (mBleState, parseRssiThreshold thresholdText) of
-    (Nothing, _) -> setStatus appState "BLE state not ready"
-    (Just _, Left thresholdError) -> setStatus appState thresholdError
-    (Just bleState, Right threshold) -> do
-      writeIORef (stateBeacons appState) []
-      writeIORef (stateSeenAddresses appState) Set.empty
-      writeIORef (stateScanning appState) True
-      startBleScan bleState (onScanResult appState threshold)
-      setStatus appState
-        ("scanning for KBeacons (RSSI over " <> pack (show threshold) <> " dBm)")
+  adapterStatus <- checkBleAdapter
+  case scanRefusalForAdapter adapterStatus of
+    Just refusal -> setStatus appState refusal
+    Nothing -> do
+      mBleState <- readIORef (stateBle appState)
+      thresholdText <- readIORef (stateThresholdInput appState)
+      case (mBleState, parseRssiThreshold thresholdText) of
+        (Nothing, _) -> setStatus appState "BLE state not ready"
+        (Just _, Left thresholdError) -> setStatus appState thresholdError
+        (Just bleState, Right threshold) -> do
+          writeIORef (stateBeacons appState) []
+          writeIORef (stateSeenAddresses appState) Set.empty
+          writeIORef (stateScanning appState) True
+          startBleScan bleState (onScanResult appState threshold)
+          setStatus appState
+            ("scanning for KBeacons (RSSI over " <> pack (show threshold) <> " dBm)")
 
 -- | Parse the RSSI threshold input. Refuses to scan on nonsense
 -- rather than guessing a value. The accepted range is the full signed
@@ -284,26 +361,35 @@ parseRssiThreshold input =
         else Left ("invalid RSSI threshold: " <> input)
     Left _ -> Left ("invalid RSSI threshold: " <> input)
 
--- | Scan callback: KKM identity gate, then the RSSI threshold and
--- dedup of the original Scanner.kt (including its log lines).
---
--- The scan is unfiltered, so this fires for every BLE device in
--- range and must stay quiet about them: an address that was already
--- listed or already judged foreign returns silently, a fresh foreign
--- device is logged once when its address is remembered. A weak
--- KBeacon is NOT remembered: its signal fluctuates, so a later
--- stronger advertisement must still be able to list it. An
--- undecidable result (opaque iOS address, no usable name yet) is
--- dropped without memory because a later scan response may carry the
--- name that identifies it.
+-- | The scan callback as registered with the platform: stamps the
+-- arrival time and hands over to 'onScanResultAt'.
 onScanResult :: AppState -> Int -> BleScanResult -> IO ()
 onScanResult appState threshold result = do
+  now <- getPOSIXTime
+  onScanResultAt now appState threshold result
+
+-- | Scan callback body: KKM identity gate, then the RSSI threshold
+-- and dedup of the original Scanner.kt (including its log lines).
+--
+-- The scan is unfiltered, so this fires for every BLE device in
+-- range and must stay quiet about them: an address already judged
+-- foreign returns silently, a fresh foreign device is logged once
+-- when its address is remembered, and a repeated advertisement from
+-- a listed beacon refreshes that beacon ('refreshBeaconSighting')
+-- instead of being dropped. A weak KBeacon is NOT remembered: its
+-- signal fluctuates, so a later stronger advertisement must still be
+-- able to list it. An undecidable result (opaque iOS address, no
+-- name or MAC marker yet) is dropped without memory because a later
+-- callback may carry what identifies it.
+onScanResultAt :: POSIXTime -> AppState -> Int -> BleScanResult -> IO ()
+onScanResultAt now appState threshold result = do
   let address = unBleDeviceAddress (bsrDeviceAddress result)
       rssi = bsrRssi result
+      extData = scanResultExtData result
   seen <- readIORef (stateSeenAddresses appState)
   if Set.member address seen
-    then pure ()
-    else case identifyScanResult address (bsrDeviceName result) of
+    then refreshBeaconSighting now appState result extData
+    else case identifyScanResult extData address (bsrDeviceName result) of
       IdentityUnknown -> pure ()
       ForeignDevice -> do
         modifyIORef' (stateSeenAddresses appState) (Set.insert address)
@@ -316,12 +402,75 @@ onScanResult appState threshold result = do
             modifyIORef' (stateBeacons appState) (\beacons -> DiscoveredBeacon
               { beaconTarget = scanResultTarget mac result
               , beaconRssi = rssi
-              , beaconStatus = StatusDiscovered
+              , beaconBattery = extData >>= kkmExtDataBattery
+              , beaconLastSeenAt = now
+              , beaconIntervalMs = Nothing
+              , beaconStatus = StatusFound
               , beaconReportNote = Nothing
               } : beacons)
             platformLog ("found beacon " <> bsrDeviceName result
               <> " " <> address <> " rssi=" <> pack (show rssi))
             requestRepaint appState
+
+-- | KKM's 0x2080 service data from a scan result. A malformed
+-- advertisement (Left) reads as no service data here: hatter's scan
+-- dispatch has already logged every defect loudly, with the address.
+scanResultExtData :: BleScanResult -> Maybe ByteString
+scanResultExtData result = case bsrAdvertisement result of
+  Left _ -> Nothing
+  Right advertisement ->
+    serviceDataForUuid kkmExtDataServiceUuidText advertisement
+
+-- | Refresh a listed beacon from a repeated advertisement: RSSI and
+-- battery update, and the advertisement interval is measured from
+-- the arrival times. Repeats from addresses that are remembered but
+-- not listed (foreign devices) do nothing.
+refreshBeaconSighting :: POSIXTime -> AppState -> BleScanResult -> Maybe ByteString -> IO ()
+refreshBeaconSighting now appState result extData = do
+  let address = unBleDeviceAddress (bsrDeviceAddress result)
+  beacons <- readIORef (stateBeacons appState)
+  if any (beaconHasAddress address) beacons
+    then do
+      modifyIORef' (stateBeacons appState) (map (\beacon ->
+        if beaconHasAddress address beacon
+          then refreshedBeacon now (bsrRssi result) (extData >>= kkmExtDataBattery) beacon
+          else beacon))
+      requestRepaint appState
+    else pure ()
+
+-- | Does this row belong to the given scan address?
+beaconHasAddress :: Text -> DiscoveredBeacon -> Bool
+beaconHasAddress address beacon =
+  unBleDeviceAddress (targetAddress (beaconTarget beacon)) == address
+
+-- | One beacon row after another advertisement arrived: new RSSI,
+-- battery when the advertisement carried one, and the measured
+-- interval updated from the arrival delta.
+--
+-- Decision: the interval is an exponentially smoothed average
+-- (3 parts old, 1 part new) rather than the raw last delta. Android
+-- delivers scan results with jitter and the radio adds a random
+-- 0..10 ms advertising delay per event, so the raw delta jumps
+-- around; smoothing shows a stable number that still converges
+-- within a few advertisements after a period change. A delta of
+-- zero milliseconds (batched duplicate delivery) is not a
+-- measurement and is skipped.
+refreshedBeacon :: POSIXTime -> Int -> Maybe Int -> DiscoveredBeacon -> DiscoveredBeacon
+refreshedBeacon now rssi battery beacon =
+  let deltaMs = round ((now - beaconLastSeenAt beacon) * 1000) :: Int
+      interval = if deltaMs <= 0
+        then beaconIntervalMs beacon
+        else case beaconIntervalMs beacon of
+          Nothing -> Just deltaMs
+          Just old -> Just ((old * 3 + deltaMs) `div` 4)
+  in beacon
+    { beaconRssi = rssi
+    , beaconBattery = case battery of
+        Just percent -> Just percent
+        Nothing -> beaconBattery beacon
+    , beaconLastSeenAt = now
+    , beaconIntervalMs = interval
+    }
 
 -- | Build the configure target for an accepted scan result.
 scanResultTarget :: BeaconMac -> BleScanResult -> BeaconTarget
@@ -449,7 +598,7 @@ outcomeReportJson outcome =
       ])
 
 -- | Print MAC bytes as "AA:BB:CC:DD:EE:FF".
-formatMacBytes :: ByteString.ByteString -> Text
+formatMacBytes :: ByteString -> Text
 formatMacBytes bytes =
   Text.intercalate ":" (map formatMacByte (ByteString.unpack bytes))
 
@@ -479,7 +628,7 @@ onConfigureFinished appState = do
   writeIORef (stateConfiguring appState) False
   setStatus appState "configuration finished"
 
--- | Build the widget tree from the current state.
+-- | Build the widget tree for the current page.
 appView
   :: AppState
   -> Action -> Action -> Action -> Action -> Action
@@ -488,17 +637,42 @@ appView
 appView appState
         onCheckAdapter onRequestPerms onStartScan onStopScan onConfigureAll
         onPeriodChange onThresholdChange onReportUrlChange = do
+  page <- readIORef (statePage appState)
+  case page of
+    PermissionPage -> permissionPageView appState onRequestPerms
+    ScannerPage -> scannerPageView appState
+      onCheckAdapter onStartScan onStopScan onConfigureAll
+      onPeriodChange onThresholdChange onReportUrlChange
+
+-- | The one-time permission page; 'continuePastPermissions' replaces
+-- it with the scanner page once both permissions are granted.
+permissionPageView :: AppState -> Action -> IO Widget
+permissionPageView appState onRequestPerms = do
+  statusLine <- readIORef (stateStatusLine appState)
+  pure (column
+    [ text "Finding KBeacons needs the bluetooth scan and location permissions."
+    , button "Request Permissions" onRequestPerms
+    , text ("Status: " <> statusLine)
+    ])
+
+-- | The scanner page: inputs, the scan toggle, and the beacon list.
+scannerPageView
+  :: AppState
+  -> Action -> Action -> Action -> Action
+  -> OnChange -> OnChange -> OnChange
+  -> IO Widget
+scannerPageView appState
+                onCheckAdapter onStartScan onStopScan onConfigureAll
+                onPeriodChange onThresholdChange onReportUrlChange = do
   beacons <- readIORef (stateBeacons appState)
   advPeriod <- readIORef (stateAdvPeriodInput appState)
   threshold <- readIORef (stateThresholdInput appState)
   reportUrl <- readIORef (stateReportUrlInput appState)
   scanning <- readIORef (stateScanning appState)
   statusLine <- readIORef (stateStatusLine appState)
+  let expectedPeriod = parseAdvPeriod advPeriod
   pure (column
-    [ row
-        [ button "Check Adapter" onCheckAdapter
-        , button "Request Permissions" onRequestPerms
-        ]
+    [ button "Check Adapter" onCheckAdapter
     , TextInput TextInputConfig
         { tiInputType  = InputNumber
         , tiHint       = "Adv interval (ms)"
@@ -524,22 +698,67 @@ appView appState
         , tiAutoFocus  = False
         }
     , row
-        [ button "Start Scan" onStartScan
-        , button "Stop Scan" onStopScan
+        [ if scanning
+            then button "Stop Scan" onStopScan
+            else button "Start Scan" onStartScan
         , button "Configure All" onConfigureAll
         ]
     , text ("Status: " <> statusLine)
     , text ("Scanning: " <> (if scanning then "yes" else "no")
         <> " | " <> pack (show (length beacons)) <> " device(s) found")
-    , scrollColumn (map beaconRow (reverse beacons))
+    , scrollColumn (map (beaconRow expectedPeriod) (reverse beacons))
     ])
 
--- | One row per discovered beacon.
-beaconRow :: DiscoveredBeacon -> Widget
-beaconRow beacon =
+-- | How a beacon's measured advertisement interval relates to the
+-- expected interval input.
+data RateVerdict
+  = RateUnknown
+    -- ^ No measurement yet, or no valid expected interval to compare
+    -- against.
+  | RateMatching
+  | RateDeviating
+  deriving (Show, Eq)
+
+-- | Compare the measured interval with the expected one.
+--
+-- Decision: matching means within 25% of the expected interval. BLE
+-- adds a random 0..10 ms delay to every advertising event and the
+-- platform delivers results with its own jitter, so exact matching
+-- would flag healthy beacons; a beacon actually configured to a
+-- different period (the closest firmware steps are well over 25%
+-- apart) still lands far outside the band.
+rateVerdict :: Either Text AdvPeriodMs -> Maybe Int -> RateVerdict
+rateVerdict expected measured =
+  case (expected, measured) of
+    (Left _, _) -> RateUnknown
+    (_, Nothing) -> RateUnknown
+    (Right expectedPeriod, Just measuredMs) ->
+      if abs (measuredMs - unAdvPeriodMs expectedPeriod) * 4
+           <= unAdvPeriodMs expectedPeriod
+        then RateMatching
+        else RateDeviating
+
+-- | Row text color for a rate verdict: green when the beacon
+-- advertises at the expected rate, red when it deviates, unstyled
+-- while unknown.
+rateColor :: RateVerdict -> Maybe Color
+rateColor verdict = case verdict of
+  RateUnknown -> Nothing
+  RateMatching -> Just (Color 0x2E 0x7D 0x32 0xFF)
+  RateDeviating -> Just (Color 0xC6 0x28 0x28 0xFF)
+
+-- | One row per discovered beacon, colored by its rate verdict.
+beaconRow :: Either Text AdvPeriodMs -> DiscoveredBeacon -> Widget
+beaconRow expectedPeriod beacon =
   let target = beaconTarget beacon
+      batteryText = case beaconBattery beacon of
+        Just percent -> " | " <> pack (show percent) <> "%"
+        Nothing -> ""
+      rateText = case beaconIntervalMs beacon of
+        Just intervalMs -> " | ~" <> pack (show intervalMs) <> " ms"
+        Nothing -> ""
       statusText = case beaconStatus beacon of
-        StatusDiscovered -> "discovered"
+        StatusFound -> "found"
         StatusConfiguring -> "configuring..."
         StatusConfigured success ->
           "set to " <> pack (show (unAdvPeriodMs (successAppliedPeriod success))) <> " ms"
@@ -550,11 +769,15 @@ beaconRow beacon =
       reportText = case beaconReportNote beacon of
         Just note -> " | " <> note
         Nothing -> ""
-  in column
-    [ row
-        [ text (targetName target)
-        , text (" | " <> unBleDeviceAddress (targetAddress target))
-        , text (" | RSSI: " <> pack (show (beaconRssi beacon)))
+      rowWidget = column
+        [ row
+            [ text (targetName target)
+            , text (" | " <> unBleDeviceAddress (targetAddress target))
+            , text (" | RSSI: " <> pack (show (beaconRssi beacon)))
+            , text (batteryText <> rateText)
+            ]
+        , text ("   " <> statusText <> reportText)
         ]
-    , text ("   " <> statusText <> reportText)
-    ]
+  in case rateColor (rateVerdict expectedPeriod (beaconIntervalMs beacon)) of
+    Nothing -> rowWidget
+    Just color -> Styled defaultStyle { wsTextColor = Just color } rowWidget

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -78,6 +78,7 @@ import Hatter.AppContext (AppContext(..), derefAppContext)
 import Hatter.Ble
   ( BleScanResult(..)
   , BleAdapterStatus(..)
+  , BleAdvertisementWithErrors(..)
   , BleDeviceAddress(..)
   , BleState
   , checkBleAdapter
@@ -413,11 +414,14 @@ onScanResultAt now appState threshold result = do
             requestRepaint appState
 
 -- | KKM's 0x2080 service data from a scan result. A malformed
--- advertisement (Left) reads as no service data here: hatter's scan
--- dispatch has already logged every defect loudly, with the address.
+-- advertisement still contributes its salvaged partial (hatter's
+-- scan dispatch has already logged every defect loudly, with the
+-- address): a beacon with one garbled structure must not lose its
+-- valid identity data.
 scanResultExtData :: BleScanResult -> Maybe ByteString
 scanResultExtData result = case bsrAdvertisement result of
-  Left _ -> Nothing
+  Left withErrors ->
+    serviceDataForUuid kkmExtDataServiceUuid (partialAdvertisement withErrors)
   Right advertisement ->
     serviceDataForUuid kkmExtDataServiceUuid advertisement
 

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -775,7 +775,11 @@ beaconRow expectedPeriod beacon =
             [ text (targetName target)
             , text (" | " <> unBleDeviceAddress (targetAddress target))
             , text (" | RSSI: " <> pack (show (beaconRssi beacon)))
-            , text (batteryText <> rateText)
+            -- Battery and rate are separate nodes so the emulator
+            -- test can exact-match the deterministic battery text
+            -- while the measured rate varies.
+            , text batteryText
+            , text rateText
             ]
         , text ("   " <> statusText <> reportText)
         ]

--- a/src/KBeacon/Protocol.hs
+++ b/src/KBeacon/Protocol.hs
@@ -26,7 +26,7 @@ module KBeacon.Protocol
   , macFromName
   , ScanIdentity(..)
   , identifyScanResult
-  , kkmExtDataServiceUuidText
+  , kkmExtDataServiceUuid
   , kkmExtDataBattery
   , kkmExtDataMac
     -- * Auth handshake
@@ -80,6 +80,8 @@ import Data.Char (isHexDigit)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
+import Data.UUID.Types (UUID)
+import Data.UUID.Types qualified as UUID
 import Data.Word (Word8)
 import KBeacon.Json
   ( JsonValue(..)
@@ -223,11 +225,13 @@ identifyScanResult maybeExtData address name =
           Just mac -> KkmBeacon mac
           Nothing -> IdentityUnknown
 
--- | KKM's "ext data" service UUID (0x2080), the key under which
--- KBeacons broadcast 'kkmExtDataBattery' and 'kkmExtDataMac' as
--- service data. Pass to 'Hatter.BleAdvertisement.serviceDataForUuid'.
-kkmExtDataServiceUuidText :: Text
-kkmExtDataServiceUuidText = "00002080-0000-1000-8000-00805F9B34FB"
+-- | KKM's "ext data" service UUID (0x2080 aliased into the
+-- Bluetooth base UUID), the key under which KBeacons broadcast
+-- 'kkmExtDataBattery' and 'kkmExtDataMac' as service data. Pass to
+-- 'Hatter.BleAdvertisement.serviceDataForUuid'; built with the total
+-- 'UUID.fromWords', so no literal can be malformed.
+kkmExtDataServiceUuid :: UUID
+kkmExtDataServiceUuid = UUID.fromWords 0x00002080 0x00001000 0x80000080 0x5F9B34FB
 
 -- | Battery percent from a 0x2080 service data payload: byte 0,
 -- clamped to 100, and only trusted when the payload is longer than

--- a/src/KBeacon/Protocol.hs
+++ b/src/KBeacon/Protocol.hs
@@ -26,6 +26,9 @@ module KBeacon.Protocol
   , macFromName
   , ScanIdentity(..)
   , identifyScanResult
+  , kkmExtDataServiceUuidText
+  , kkmExtDataBattery
+  , kkmExtDataMac
     -- * Auth handshake
   , BeaconPassword(..)
   , defaultBeaconPassword
@@ -145,12 +148,10 @@ parseHexByte part =
 --
 -- Decision: needed because iOS never exposes MAC addresses to
 -- applications (CoreBluetooth hands out per-phone UUIDs) while the
--- auth MD5 is keyed on the MAC. KKM's own iOS library solves this by
--- parsing the MAC out of the raw advertisement service data, which
--- hatter's scan API does not expose (yet, see the README); the name
--- suffix carries the same three bytes for factory-named beacons.
--- Renamed beacons cannot be configured from iOS until hatter exposes
--- advertisement payloads.
+-- auth MD5 is keyed on the MAC. The primary iOS path is
+-- 'kkmExtDataMac' (the MAC bytes inside the 0x2080 service data,
+-- which is what KKM's own iOS library parses); the name suffix
+-- covers factory-named beacons whose frame carried no service data.
 macFromName :: Text -> Maybe BeaconMac
 macFromName name =
   let suffix = Text.takeEnd 6 name
@@ -175,9 +176,23 @@ data ScanIdentity
     -- callback, so the address must not be written off.
   deriving (Show, Eq)
 
--- | Classify one scan result. On Android the address is the real MAC
--- and its vendor prefix decides; on iOS (opaque address) the factory
--- name suffix reconstructs the MAC, see 'macFromName'.
+-- | Classify one scan result from its 0x2080 service data payload
+-- (when the advertisement carried one), its address and its name.
+--
+-- The service data is the primary signal: it is how KKM's own
+-- library recognises its hardware, so a device broadcasting it is a
+-- KBeacon regardless of its MAC prefix. The auth MAC is then the
+-- advertised address when it is a real MAC (Android reports the true
+-- address, which is what the beacon keys its auth digest on), the
+-- MAC bytes inside the service data ('kkmExtDataMac', which is how
+-- KKM's iOS library recovers MACs, including for renamed beacons),
+-- or the factory name suffix. A KBeacon whose MAC cannot be
+-- recovered yet stays 'IdentityUnknown' so a later callback carrying
+-- the name or the MAC marker can still list it.
+--
+-- Without service data (a KBeacon slot broadcasting pure
+-- iBeacon/Eddystone frames, or any other device) the MAC prefix
+-- decides on Android and the factory name on iOS.
 --
 -- Decision: identify KBeacons in software instead of a hardware scan
 -- filter. The tool used to scan with an Android ScanFilter on KKM's
@@ -188,20 +203,56 @@ data ScanIdentity
 -- KBeaconsMgr works around this by OR-ing four filters (Eddystone
 -- FEAA, 0x2080, iBeacon and KKM manufacturer data) and then
 -- identifying KKM frames while parsing advertisement payloads;
--- hatter's scan API exposes neither multiple filters nor payloads, so
--- the tool scans unfiltered and selects on KKM's MAC prefix, which is
--- more selective than KKM's filter list anyway (other vendors'
--- Eddystone or iBeacon hardware never matches).
-identifyScanResult :: Text -> Text -> ScanIdentity
-identifyScanResult address name =
+-- hatter delivers the payloads since jappeace/hatter#238, so the
+-- tool scans unfiltered and identifies on the 0x2080 service data
+-- exactly like KKM does, with the MAC prefix as the fallback for
+-- payload-less frames.
+identifyScanResult :: Maybe ByteString -> Text -> Text -> ScanIdentity
+identifyScanResult maybeExtData address name =
   case macFromAddress address of
     Just mac ->
       if macHasKkmOui mac
         then KkmBeacon mac
-        else ForeignDevice
-    Nothing -> case macFromName name of
-      Just mac -> KkmBeacon mac
-      Nothing -> IdentityUnknown
+        else case maybeExtData of
+          Just _ -> KkmBeacon mac
+          Nothing -> ForeignDevice
+    Nothing ->
+      case maybeExtData >>= kkmExtDataMac of
+        Just mac -> KkmBeacon mac
+        Nothing -> case macFromName name of
+          Just mac -> KkmBeacon mac
+          Nothing -> IdentityUnknown
+
+-- | KKM's "ext data" service UUID (0x2080), the key under which
+-- KBeacons broadcast 'kkmExtDataBattery' and 'kkmExtDataMac' as
+-- service data. Pass to 'Hatter.BleAdvertisement.serviceDataForUuid'.
+kkmExtDataServiceUuidText :: Text
+kkmExtDataServiceUuidText = "00002080-0000-1000-8000-00805F9B34FB"
+
+-- | Battery percent from a 0x2080 service data payload: byte 0,
+-- clamped to 100, and only trusted when the payload is longer than
+-- two bytes, mirroring KKM's own parser
+-- (KBAdvPacketHandler.java: @batteryPercent = byExtenData[0]@ under
+-- @length > 2@, capped at 100).
+kkmExtDataBattery :: ByteString -> Maybe Int
+kkmExtDataBattery extData =
+  if BS.length extData > 2
+    then Just (min 100 (Word8.toInt (BS.index extData 0)))
+    else Nothing
+
+-- | The beacon's MAC recovered from a 0x2080 service data payload:
+-- when byte 1 (beacon type flags) is 0 and byte 2 is the marker 1,
+-- bytes 3 to 5 are the MAC's low three bytes under KKM's OUI. This
+-- mirrors KBAdvPacketHandler.swift, which is how KKM's iOS library
+-- learns MACs at all (and the only way for renamed beacons, whose
+-- name no longer encodes the MAC).
+kkmExtDataMac :: ByteString -> Maybe BeaconMac
+kkmExtDataMac extData =
+  if BS.length extData > 5
+      && BS.index extData 1 == 0x00
+      && BS.index extData 2 == 0x01
+    then Just (BeaconMac (kkmOuiPrefix <> BS.take 3 (BS.drop 3 extData)))
+    else Nothing
 
 -- | Whether the MAC starts with KKM's OUI BC:57:29, ignoring the top
 -- two bits of the first byte (masked, BC becomes 3C).

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -510,6 +510,28 @@ scanUiTests = testGroup "scan signal to ui"
       assertEqual "auth mac recovered from the service data"
         [Just (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x4D, 0x5E, 0x6F]))]
         (map (targetMac . beaconTarget) beacons)
+  , testCase "a malformed advertisement still identifies via its salvage" $ do
+      -- Valid 0x2080 service data followed by a truncated structure:
+      -- hatter reports the defect but salvages the partial, and the
+      -- identity gate must use it. The opaque address and non-factory
+      -- name guarantee the ext data is the only identity source, so
+      -- this fails if the Left branch degrades to "no service data".
+      let malformedAdvertisement = parseBleAdvertisement (BS.pack
+            [ 0x02, 0x01, 0x06
+            , 0x09, 0x16, 0x80, 0x20, 85, 0x00, 0x01, 0x4D, 0x5E, 0x6F
+            , 0x09, 0x16, 0xED
+            ])
+      assertBool "fixture must be a defective parse"
+        (isLeft malformedAdvertisement)
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold
+        iosRenamedKBeaconSignal { bsrAdvertisement = malformedAdvertisement }
+      beacons <- readIORef (stateBeacons appState)
+      assertEqual "identity recovered from the salvaged service data"
+        [Just (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x4D, 0x5E, 0x6F]))]
+        (map (targetMac . beaconTarget) beacons)
+      assertEqual "battery from the salvaged service data"
+        [Just 85] (map beaconBattery beacons)
   , testCase "a payload-less unnamed iOS callback waits for the name" $ do
       (appState, repaints) <- newScannerAppState
       onScanResultAt 10 appState defaultRssiThreshold

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -13,14 +13,23 @@ import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Hatter (newActionState, runActionM, createAction, createOnChange)
-import Hatter.Ble (BleScanResult(..), BleDeviceAddress(..))
+import Hatter.Ble
+  ( BleScanResult(..)
+  , BleAdapterStatus(..)
+  , BleDeviceAddress(..)
+  , emptyBleAdvertisement
+  , parseBleAdvertisement
+  )
+import Hatter.Permission (PermissionStatus(..))
 import Hatter.Widget
   ( ButtonConfig(..)
+  , Color(..)
   , LayoutItem(..)
   , LayoutSettings(..)
   , TextConfig(..)
   , TextInputConfig(..)
   , Widget(..)
+  , WidgetStyle(..)
   )
 import KBeacon.Configure (BeaconTarget(..))
 import KBeacon.Json
@@ -31,12 +40,17 @@ import KBeacon.Json
   , renderJson
   )
 import KBeacon.OtaApp
-  ( AppState(..)
+  ( AppPage(..)
+  , AppState(..)
   , DiscoveredBeacon(..)
+  , RateVerdict(..)
   , appView
+  , continuePastPermissions
   , defaultRssiThreshold
   , newAppState
-  , onScanResult
+  , onScanResultAt
+  , rateVerdict
+  , scanRefusalForAdapter
   )
 import KBeacon.Protocol
   ( AdvSlot(..)
@@ -64,6 +78,8 @@ import KBeacon.Protocol
   , macFromName
   , ScanIdentity(..)
   , identifyScanResult
+  , kkmExtDataBattery
+  , kkmExtDataMac
   , negotiatedFrameBudget
   , parseBeaconNotification
   , parseParaResponse
@@ -171,22 +187,50 @@ macTests = testGroup "mac derivation"
   , testCase "identifies a KKM-prefixed address as a beacon" $
       assertEqual "identity"
         (KkmBeacon (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x1A, 0x2B, 0x3C])))
-        (identifyScanResult "BC:57:29:1A:2B:3C" "KBPro-1A2B3C")
+        (identifyScanResult Nothing "BC:57:29:1A:2B:3C" "KBPro-1A2B3C")
   , testCase "accepts the static-random spelling of the KKM prefix" $
       assertEqual "identity"
         (KkmBeacon (BeaconMac (BS.pack [0xFC, 0x57, 0x29, 0xF4, 0xF5, 0xF6])))
-        (identifyScanResult "FC:57:29:F4:F5:F6" "KBPro-F4F5F6")
+        (identifyScanResult Nothing "FC:57:29:F4:F5:F6" "KBPro-F4F5F6")
   , testCase "the address verdict beats a KKM-looking name" $
       assertEqual "identity" ForeignDevice
-        (identifyScanResult "AA:BB:CC:DD:EE:FF" "KBPro-1A2B3C")
+        (identifyScanResult Nothing "AA:BB:CC:DD:EE:FF" "KBPro-1A2B3C")
   , testCase "falls back to the name on iOS-style addresses" $
       assertEqual "identity"
         (KkmBeacon (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x1A, 0x2B, 0x3C])))
-        (identifyScanResult "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D" "KBPro-1A2B3C")
+        (identifyScanResult Nothing "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D" "KBPro-1A2B3C")
   , testCase "cannot decide an iOS address without a factory name" $
       assertEqual "identity" IdentityUnknown
-        (identifyScanResult "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D" "office speaker")
+        (identifyScanResult Nothing "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D" "office speaker")
+  , testCase "ext data outvotes a foreign MAC prefix" $
+      assertEqual "identity"
+        (KkmBeacon (BeaconMac (BS.pack [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF])))
+        (identifyScanResult (Just vectorExtData) "AA:BB:CC:DD:EE:FF" "")
+  , testCase "ext data recovers the MAC of a renamed beacon on iOS" $
+      assertEqual "identity"
+        (KkmBeacon (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x4D, 0x5E, 0x6F])))
+        (identifyScanResult (Just vectorExtData)
+          "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D" "conference room")
+  , testCase "ext data battery is byte 0, clamped like KKM's parser" $ do
+      assertEqual "battery" (Just 85) (kkmExtDataBattery vectorExtData)
+      assertEqual "clamped" (Just 100)
+        (kkmExtDataBattery (BS.pack [200, 0x00, 0x01]))
+      assertEqual "too short" Nothing (kkmExtDataBattery (BS.pack [85, 0x00]))
+  , testCase "the MAC marker gates the ext data MAC bytes" $ do
+      assertEqual "marked" (Just (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x4D, 0x5E, 0x6F])))
+        (kkmExtDataMac vectorExtData)
+      assertEqual "marker byte not 1" Nothing
+        (kkmExtDataMac (BS.pack [85, 0x00, 0x00, 0x4D, 0x5E, 0x6F]))
+      assertEqual "type flags not 0" Nothing
+        (kkmExtDataMac (BS.pack [85, 0x04, 0x01, 0x4D, 0x5E, 0x6F]))
+      assertEqual "too short" Nothing
+        (kkmExtDataMac (BS.pack [85, 0x00, 0x01, 0x4D, 0x5E]))
   ]
+
+-- | A KKM 0x2080 service data payload: battery 85, type flags 0, MAC
+-- marker 1, low MAC bytes 4D 5E 6F.
+vectorExtData :: ByteString
+vectorExtData = BS.pack [85, 0x00, 0x01, 0x4D, 0x5E, 0x6F]
 
 authTests :: TestTree
 authTests = testGroup "auth handshake"
@@ -348,102 +392,222 @@ unAssembly :: ReportAssembly -> ByteString
 unAssembly = unReportAssembly
 
 -- | Integration tests for the signal-to-UI path: the scan callback
--- the app registers with the platform ('onScanResult') is fed
--- fabricated results, and the widget tree the app registers as its
--- view ('appView') must reflect them. The redraw hook stands in for
--- the platform's render loop, so the tests also prove the app asks
--- for a repaint when (and only when) the list changed.
+-- the app registers with the platform ('onScanResultAt', clock
+-- injected) is fed fabricated results, and the widget tree the app
+-- registers as its view ('appView') must reflect them. The redraw
+-- hook stands in for the platform's render loop, so the tests also
+-- prove the app asks for a repaint when the list changed.
 scanUiTests :: TestTree
 scanUiTests = testGroup "scan signal to ui"
-  [ testCase "a KBeacon signal adds a listed row and repaints" $ do
-      (appState, repaints) <- newCountingAppState
+  [ testCase "a KBeacon signal adds a listed row with its battery" $ do
+      (appState, repaints) <- newScannerAppState
       textsBefore <- renderedAppTexts appState
       assertBool "beacon must not be listed before the signal"
         (not (any (Text.isInfixOf "KBPro-4D5E6F") textsBefore))
-      onScanResult appState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
       repaintCount <- readIORef repaints
       assertEqual "repaints after the signal" 1 repaintCount
       textsAfter <- renderedAppTexts appState
       assertBool "beacon row rendered after the signal"
         (any (Text.isInfixOf "KBPro-4D5E6F") textsAfter)
+      assertBool "battery from the advertisement rendered"
+        (any (Text.isInfixOf "85%") textsAfter)
       assertBool "device count reflects the discovery"
         (any (Text.isInfixOf "1 device(s) found") textsAfter)
-  , testCase "a repeated advertisement neither duplicates nor repaints" $ do
-      (appState, repaints) <- newCountingAppState
-      onScanResult appState defaultRssiThreshold androidKBeaconSignal
-      onScanResult appState defaultRssiThreshold androidKBeaconSignal
+  , testCase "a repeated advertisement refreshes the row, not duplicates it" $ do
+      (appState, repaints) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 11 appState defaultRssiThreshold
+        androidKBeaconSignal { bsrRssi = -60 }
       beacons <- readIORef (stateBeacons appState)
       assertEqual "listed once" 1 (length beacons)
+      assertEqual "rssi refreshed" [-60] (map beaconRssi beacons)
       repaintCount <- readIORef repaints
-      assertEqual "repainted once" 1 repaintCount
+      assertEqual "repainted for both the listing and the refresh" 2 repaintCount
+  , testCase "repeated advertisements measure the interval, smoothed" $ do
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 11 appState defaultRssiThreshold androidKBeaconSignal
+      beaconsAfterTwo <- readIORef (stateBeacons appState)
+      assertEqual "first measurement is the delta"
+        [Just 1000] (map beaconIntervalMs beaconsAfterTwo)
+      onScanResultAt 12.2 appState defaultRssiThreshold androidKBeaconSignal
+      beaconsAfterThree <- readIORef (stateBeacons appState)
+      assertEqual "smoothed three parts old, one part new"
+        [Just 1050] (map beaconIntervalMs beaconsAfterThree)
+  , testCase "the measured rate colors the row against the expected interval" $ do
+      (appState, _) <- newScannerAppState
+      writeIORef (stateAdvPeriodInput appState) "1000"
+      onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
+      colorsBefore <- fmap widgetTextColors (renderedAppWidget appState)
+      assertEqual "no color before a measurement" 0 (length colorsBefore)
+      onScanResultAt 11 appState defaultRssiThreshold androidKBeaconSignal
+      colorsMatching <- fmap widgetTextColors (renderedAppWidget appState)
+      assertEqual "one colored row at the expected rate" 1 (length colorsMatching)
+      (slowState, _) <- newScannerAppState
+      writeIORef (stateAdvPeriodInput slowState) "1000"
+      onScanResultAt 10 slowState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 15 slowState defaultRssiThreshold androidKBeaconSignal
+      colorsDeviating <- fmap widgetTextColors (renderedAppWidget slowState)
+      assertEqual "one colored row at a deviating rate" 1 (length colorsDeviating)
+      assertBool "matching and deviating rates color differently"
+        (colorsMatching /= colorsDeviating)
+  , testCase "rateVerdict tolerates jitter but flags another period" $ do
+      assertEqual "exact" RateMatching
+        (rateVerdict (validateAdvPeriod 1000) (Just 1000))
+      assertEqual "within tolerance" RateMatching
+        (rateVerdict (validateAdvPeriod 1000) (Just 1249))
+      assertEqual "too slow" RateDeviating
+        (rateVerdict (validateAdvPeriod 1000) (Just 1260))
+      assertEqual "too fast" RateDeviating
+        (rateVerdict (validateAdvPeriod 1000) (Just 700))
+      assertEqual "no measurement" RateUnknown
+        (rateVerdict (validateAdvPeriod 1000) Nothing)
+      assertEqual "invalid expectation" RateUnknown
+        (rateVerdict (Left "invalid") (Just 1000))
   , testCase "a weak signal stays out of the list until it strengthens" $ do
-      (appState, repaints) <- newCountingAppState
-      onScanResult appState defaultRssiThreshold
+      (appState, repaints) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold
         androidKBeaconSignal { bsrRssi = -80 }
       weakBeacons <- readIORef (stateBeacons appState)
       assertEqual "not listed while weak" 0 (length weakBeacons)
       weakRepaints <- readIORef repaints
       assertEqual "no repaint while weak" 0 weakRepaints
-      onScanResult appState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 11 appState defaultRssiThreshold androidKBeaconSignal
       strongBeacons <- readIORef (stateBeacons appState)
       assertEqual "listed once strong" 1 (length strongBeacons)
   , testCase "foreign hardware is never listed" $ do
-      (appState, repaints) <- newCountingAppState
-      onScanResult appState defaultRssiThreshold BleScanResult
+      (appState, repaints) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold BleScanResult
         { bsrDeviceName = "NotABeacon"
         , bsrDeviceAddress = BleDeviceAddress "F0:F1:F2:F3:F4:F5"
         , bsrRssi = -30
+        , bsrAdvertisement = Right emptyBleAdvertisement
         }
       beacons <- readIORef (stateBeacons appState)
       assertEqual "not listed" 0 (length beacons)
       repaintCount <- readIORef repaints
       assertEqual "no repaint" 0 repaintCount
   , testCase "the netsim static-random KKM prefix is listed with its MAC" $ do
-      (appState, _) <- newCountingAppState
-      onScanResult appState defaultRssiThreshold BleScanResult
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold BleScanResult
         { bsrDeviceName = "KBPro-F4F5F6"
         , bsrDeviceAddress = BleDeviceAddress "FC:57:29:F4:F5:F6"
         , bsrRssi = -40
+        , bsrAdvertisement = parseBleAdvertisement (BS.pack
+            [ 0x02, 0x01, 0x06
+            , 0x09, 0x16, 0x80, 0x20, 85, 0x00, 0x01, 0xF4, 0xF5, 0xF6
+            ])
         }
       beacons <- readIORef (stateBeacons appState)
       assertEqual "auth mac from the advertised address"
         [Just (BeaconMac (BS.pack [0xFC, 0x57, 0x29, 0xF4, 0xF5, 0xF6]))]
         (map (targetMac . beaconTarget) beacons)
-  , testCase "an unnamed iOS callback waits for the named scan response" $ do
-      (appState, repaints) <- newCountingAppState
-      onScanResult appState defaultRssiThreshold
-        iosKBeaconSignal { bsrDeviceName = "" }
+  , testCase "ext data lists a renamed beacon on iOS with its MAC" $ do
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold iosRenamedKBeaconSignal
+      beacons <- readIORef (stateBeacons appState)
+      assertEqual "auth mac recovered from the service data"
+        [Just (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x4D, 0x5E, 0x6F]))]
+        (map (targetMac . beaconTarget) beacons)
+  , testCase "a payload-less unnamed iOS callback waits for the name" $ do
+      (appState, repaints) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold
+        iosNamedPayloadlessSignal { bsrDeviceName = "" }
       unnamedBeacons <- readIORef (stateBeacons appState)
       assertEqual "not listed without a name" 0 (length unnamedBeacons)
-      onScanResult appState defaultRssiThreshold iosKBeaconSignal
+      onScanResultAt 11 appState defaultRssiThreshold iosNamedPayloadlessSignal
       beacons <- readIORef (stateBeacons appState)
       assertEqual "auth mac reconstructed from the name"
         [Just (BeaconMac (BS.pack [0xBC, 0x57, 0x29, 0x1A, 0x2B, 0x3C]))]
         (map (targetMac . beaconTarget) beacons)
       repaintCount <- readIORef repaints
       assertEqual "repainted for the named result" 1 repaintCount
+  , testCase "the app opens on the permission page and grants move it on" $ do
+      (appState, _) <- newCountingAppState
+      textsBefore <- renderedAppTexts appState
+      assertBool "permission button shown"
+        (any (Text.isInfixOf "Request Permissions") textsBefore)
+      assertBool "no scan controls yet"
+        (not (any (Text.isInfixOf "Start Scan") textsBefore))
+      continuePastPermissions appState PermissionGranted PermissionGranted
+      page <- readIORef (statePage appState)
+      assertEqual "page advanced" ScannerPage page
+      textsAfter <- renderedAppTexts appState
+      assertBool "scan controls shown"
+        (any (Text.isInfixOf "Start Scan") textsAfter)
+      assertBool "permission button gone"
+        (not (any (Text.isInfixOf "Request Permissions") textsAfter))
+  , testCase "a denied permission keeps the permission page up" $ do
+      (appState, _) <- newCountingAppState
+      continuePastPermissions appState PermissionGranted PermissionDenied
+      page <- readIORef (statePage appState)
+      assertEqual "page unchanged" PermissionPage page
+      texts <- renderedAppTexts appState
+      assertBool "status names the missing permission"
+        (any (Text.isInfixOf "location permission denied") texts)
+  , testCase "the scan button toggles with the scanning state" $ do
+      (appState, _) <- newScannerAppState
+      textsIdle <- renderedAppTexts appState
+      assertBool "start shown while idle" (elem "Start Scan" textsIdle)
+      assertBool "stop hidden while idle" (not (elem "Stop Scan" textsIdle))
+      writeIORef (stateScanning appState) True
+      textsScanning <- renderedAppTexts appState
+      assertBool "stop shown while scanning" (elem "Stop Scan" textsScanning)
+      assertBool "start hidden while scanning" (not (elem "Start Scan" textsScanning))
+  , testCase "only an adapter that reports on may scan" $ do
+      assertEqual "on scans" Nothing (scanRefusalForAdapter BleAdapterOn)
+      assertBool "off refuses"
+        (scanRefusalForAdapter BleAdapterOff /= Nothing)
+      assertBool "unauthorized refuses"
+        (scanRefusalForAdapter BleAdapterUnauthorized /= Nothing)
+      assertBool "unsupported refuses"
+        (scanRefusalForAdapter BleAdapterUnsupported /= Nothing)
   ]
 
 -- | A KBeacon Pro advertisement as Android delivers it: the real MAC
--- with KKM's public OUI, well above 'defaultRssiThreshold'.
+-- with KKM's public OUI, flags plus 0x2080 service data (battery 85,
+-- MAC marker, low MAC bytes 4D 5E 6F), well above
+-- 'defaultRssiThreshold'.
 androidKBeaconSignal :: BleScanResult
 androidKBeaconSignal = BleScanResult
   { bsrDeviceName = "KBPro-4D5E6F"
   , bsrDeviceAddress = BleDeviceAddress "BC:57:29:4D:5E:6F"
   , bsrRssi = -42
+  , bsrAdvertisement = parseBleAdvertisement (BS.pack
+      [ 0x02, 0x01, 0x06
+      , 0x09, 0x16, 0x80, 0x20, 85, 0x00, 0x01, 0x4D, 0x5E, 0x6F
+      ])
   }
 
--- | The same beacon as iOS delivers it: an opaque per-phone UUID for
--- the address, so only the factory name identifies it.
-iosKBeaconSignal :: BleScanResult
-iosKBeaconSignal = BleScanResult
+-- | A renamed KBeacon as iOS delivers it: opaque address, a name
+-- that no longer encodes the MAC, but the 0x2080 service data
+-- carries the MAC marker.
+iosRenamedKBeaconSignal :: BleScanResult
+iosRenamedKBeaconSignal = BleScanResult
+  { bsrDeviceName = "meeting room"
+  , bsrDeviceAddress = BleDeviceAddress "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D"
+  , bsrRssi = -42
+  , bsrAdvertisement = parseBleAdvertisement (BS.pack
+      [ 0x02, 0x01, 0x06
+      , 0x09, 0x16, 0x80, 0x20, 85, 0x00, 0x01, 0x4D, 0x5E, 0x6F
+      ])
+  }
+
+-- | A factory-named KBeacon frame without any service data (e.g. an
+-- Eddystone slot's frame) as iOS delivers it: only the name
+-- identifies it.
+iosNamedPayloadlessSignal :: BleScanResult
+iosNamedPayloadlessSignal = BleScanResult
   { bsrDeviceName = "KBPro-1A2B3C"
   , bsrDeviceAddress = BleDeviceAddress "8B7A9E31-2C44-4A0F-9E7B-5D6F0A1B2C3D"
   , bsrRssi = -42
+  , bsrAdvertisement = Right emptyBleAdvertisement
   }
 
 -- | App state whose redraw hook counts repaints, standing in for the
--- platform's render loop.
+-- platform's render loop; opens on the permission page like the real
+-- app.
 newCountingAppState :: IO (AppState, IORef Int)
 newCountingAppState = do
   appState <- newAppState
@@ -451,19 +615,29 @@ newCountingAppState = do
   writeIORef (stateRedraw appState) (modifyIORef' repaints (+ 1))
   pure (appState, repaints)
 
--- | Render the app's view with inert button and input handles and
--- collect every text fragment the widget tree would display.
-renderedAppTexts :: AppState -> IO [Text]
-renderedAppTexts appState = do
+-- | 'newCountingAppState' already past the permission page, for the
+-- scan tests.
+newScannerAppState :: IO (AppState, IORef Int)
+newScannerAppState = do
+  (appState, repaints) <- newCountingAppState
+  writeIORef (statePage appState) ScannerPage
+  pure (appState, repaints)
+
+-- | Render the app's view with inert button and input handles.
+renderedAppWidget :: AppState -> IO Widget
+renderedAppWidget appState = do
   actionState <- newActionState
   (inertAction, inertOnChange) <- runActionM actionState $ do
     action <- createAction (pure ())
     onChange <- createOnChange (\_ -> pure ())
     pure (action, onChange)
-  widget <- appView appState
+  appView appState
     inertAction inertAction inertAction inertAction inertAction
     inertOnChange inertOnChange inertOnChange
-  pure (widgetTexts widget)
+
+-- | Every text fragment the rendered view would display.
+renderedAppTexts :: AppState -> IO [Text]
+renderedAppTexts appState = fmap widgetTexts (renderedAppWidget appState)
 
 -- | Every text fragment a widget tree renders: labels, button
 -- captions, input values and hints, in tree order.
@@ -480,3 +654,21 @@ widgetTexts = \case
   MapView _ -> []
   Styled _ inner -> widgetTexts inner
   Animated _ inner -> widgetTexts inner
+
+-- | Every text-color override applied in a widget tree, in tree
+-- order; how the rate coloring is observed.
+widgetTextColors :: Widget -> [Color]
+widgetTextColors = \case
+  Text _ -> []
+  Button _ -> []
+  TextInput _ -> []
+  Column settings -> concatMap (widgetTextColors . liWidget) (lsWidgets settings)
+  Row settings -> concatMap (widgetTextColors . liWidget) (lsWidgets settings)
+  Stack items -> concatMap (widgetTextColors . liWidget) items
+  Image _ -> []
+  WebView _ -> []
+  MapView _ -> []
+  Styled style inner -> case wsTextColor style of
+    Just color -> color : widgetTextColors inner
+    Nothing -> widgetTextColors inner
+  Animated _ inner -> widgetTextColors inner

--- a/test/android/kbeacon.sh
+++ b/test/android/kbeacon.sh
@@ -6,7 +6,9 @@
 # under various bluetooth signals. Ordered to use only two scans (see
 # the scan-rate note further down):
 #
-#   Phase 1  render + adapter: app renders, adapter reports on.
+#   Phase 1  render + permissions + adapter: app renders its
+#            permission page, granting moves it to the scanner page,
+#            adapter reports on.
 #   Phase 2  weak signal: threshold 100 dBm (above netsim's fixed +20
 #            RSSI), the beacon's advertisement is ignored and the list
 #            stays empty (RSSI proximity filter).
@@ -182,6 +184,16 @@ wait_for_logcat "kbeacon-ota starting" 30 || true
 collect_logcat "kbeacon"
 assert_logcat "$LOGCAT_FILE" "kbeacon-ota starting" "app main ran"
 
+# The app opens on the permission page; the permissions were granted
+# via pm above, so tapping Request Permissions gets granted callbacks
+# and the app moves itself to the scanner page.
+tap_button "Request Permissions" || echo "WARNING: could not tap Request Permissions"
+wait_for_logcat "permissions granted" 20 || true
+LOGCAT_PERMS="$WORK_DIR/kbeacon_perms.txt"
+"$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_PERMS" 2>&1 || true
+assert_logcat "$LOGCAT_PERMS" "permissions granted" \
+    "permission page advanced to the scanner"
+
 tap_button "Check Adapter" || echo "WARNING: could not tap Check Adapter"
 wait_for_logcat "BLE adapter: BleAdapterOn" 20 || true
 LOGCAT_ADAPTER="$WORK_DIR/kbeacon_adapter.txt"
@@ -236,6 +248,9 @@ else
     echo "PASS: decoy with a non-KKM address stayed hidden"
 fi
 assert_ui_text "Scanning: yes | 1 device(s) found" "UI shows one discovered device"
+# Battery 85 travels in the simulated 0x2080 service data and must
+# show on the row without connecting.
+assert_ui_text "85%" "battery percent shown from the advertisement"
 
 # Configure All stops the scan internally and reuses the list above,
 # so no third scan is started.

--- a/test/android/kbeacon.sh
+++ b/test/android/kbeacon.sh
@@ -250,7 +250,7 @@ fi
 assert_ui_text "Scanning: yes | 1 device(s) found" "UI shows one discovered device"
 # Battery 85 travels in the simulated 0x2080 service data and must
 # show on the row without connecting.
-assert_ui_text "85%" "battery percent shown from the advertisement"
+assert_ui_text " | 85%" "battery percent shown from the advertisement"
 
 # Configure All stops the scan internally and reuses the list above,
 # so no third scan is started.


### PR DESCRIPTION
Stacked on #4 (includes its commits until that merges). Pins hatter at the jappeace-sloth `feat/ble-advertisement-payloads` branch (jappeace/hatter#239); **repoint the pin at hatter master after #239 merges**.

## Identity via service data (hatter #238 payoff)

- `identifyScanResult` now takes the `0x2080` service data payload and treats it as the primary KKM signal, exactly like KKM's own library. MAC-prefix and factory-name fallbacks stay for payload-less frames (e.g. a slot broadcasting pure iBeacon).
- `kkmExtDataBattery` / `kkmExtDataMac` parse the payload per `KBAdvPacketHandler.java`/`.swift`: byte 0 battery (clamped to 100), bytes 3..5 the MAC's low bytes when byte 1 is 0 and byte 2 is the marker 1. This makes **renamed beacons configurable from iOS** and shows **battery without connecting**, closing both former TODO items.

## UI rework (as requested)

- **Permission page**: the app opens on it, granting both permissions moves to the scanner page and the permission UI is gone; a denial keeps the page and names the missing permission.
- **Adapter gate**: Start Scan checks the adapter first and refuses with a clear status when bluetooth is off/unauthorized/unsupported.
- **Toggle**: one button flips between Start Scan and Stop Scan (also removes the double-start footgun).
- **Live rows**: repeated advertisements refresh RSSI and battery and measure the advertisement interval (exponentially smoothed, Decision comment on the 25% tolerance); the row colors green at the expected rate and red when deviating.
- "discovered" renamed to "found".

## Tests

- The scan callback is clock-injected (`onScanResultAt`), so rate measurement and smoothing are tested with fabricated times; 63 tests pass covering the permission flow, toggle, adapter gate, coloring (via a widget-tree color walk), ext-data identity including the renamed-iOS path, and all previous behaviour. A sabotage run (EMA replaced by raw delta) failed exactly the smoothing test.
- The emulator UI test grows the permission-page step and asserts battery shows on the row straight from the advertisement.

Local verification: `cabal build` clean, 63/63 tests, shellcheck + py_compile pass. The emulator job runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)