### PR TITLE
Visible row colors, clearer row wording, skip granted permission page

### DIFF
--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,13 +4,13 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace-sloth",
+        "owner": "jappeace",
         "repo": "hatter"
       },
-      "branch": "feat/text-color-in-configs",
+      "branch": "master",
       "submodules": false,
-      "revision": "da7c188ac3667f32f2e3bfbd44d7811271e13dde",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/da7c188ac3667f32f2e3bfbd44d7811271e13dde.tar.gz",
+      "revision": "2f6d6277800693cccaba9768ca9d0ed99000de39",
+      "url": "https://github.com/jappeace/hatter/archive/2f6d6277800693cccaba9768ca9d0ed99000de39.tar.gz",
       "hash": "sha256-9p92EFoBDUkDC3uSh6/7lqSDFNO8N/TbVuAl+1bCybo="
     },
     "mobile-core-tools": {

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,14 +4,14 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace",
+        "owner": "jappeace-sloth",
         "repo": "hatter"
       },
-      "branch": "master",
+      "branch": "feat/text-color-in-configs",
       "submodules": false,
-      "revision": "b08827fc90da85eea3f5a3efd7ec85cf1a36d395",
-      "url": "https://github.com/jappeace/hatter/archive/b08827fc90da85eea3f5a3efd7ec85cf1a36d395.tar.gz",
-      "hash": "sha256-2we91fNLvzz2mL01zFraa5PXy/IN7vnJor/4CchPIyk="
+      "revision": "da7c188ac3667f32f2e3bfbd44d7811271e13dde",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/da7c188ac3667f32f2e3bfbd44d7811271e13dde.tar.gz",
+      "hash": "sha256-9p92EFoBDUkDC3uSh6/7lqSDFNO8N/TbVuAl+1bCybo="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -107,13 +107,12 @@ import Hatter.Widget
   , InputType(..)
   , TextInputConfig(..)
   , Widget(..)
+  , coloredText
   , column
-  , defaultStyle
   , row
   , scrollColumn
   , text
   , button
-  , wsTextColor
   )
 import KBeacon.Configure
   ( BeaconOutcome(..)
@@ -716,6 +715,7 @@ scannerPageView appState
         , tiValue      = advPeriod
         , tiOnChange   = onPeriodChange
         , tiFontConfig = Nothing
+        , tiTextColor  = Nothing
         , tiAutoFocus  = False
         }
     , TextInput TextInputConfig
@@ -724,6 +724,7 @@ scannerPageView appState
         , tiValue      = threshold
         , tiOnChange   = onThresholdChange
         , tiFontConfig = Nothing
+        , tiTextColor  = Nothing
         , tiAutoFocus  = False
         }
     , TextInput TextInputConfig
@@ -732,6 +733,7 @@ scannerPageView appState
         , tiValue      = reportUrl
         , tiOnChange   = onReportUrlChange
         , tiFontConfig = Nothing
+        , tiTextColor  = Nothing
         , tiAutoFocus  = False
         }
     , row
@@ -824,11 +826,9 @@ beaconRow expectedPeriod beacon =
     ]
 
 -- | A row text fragment carrying the rate color when there is one.
--- The color must sit on each text node individually: a WidgetStyle
--- applies only to the single node it wraps (Hatter.Render.applyStyle
--- sets the property on that node), so coloring the row's column
--- would set text color on a container and change nothing visible.
+-- Text color lives on the text config itself (hatter #242), so it
+-- can only ever land on glyph-bearing nodes.
 rowText :: Maybe Color -> Text -> Widget
 rowText color content = case color of
   Nothing -> text content
-  Just chosen -> Styled defaultStyle { wsTextColor = Just chosen } (text content)
+  Just chosen -> coloredText chosen content

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -99,6 +99,7 @@ import Hatter.Permission
   ( PermissionState
   , Permission(..)
   , PermissionStatus(..)
+  , checkPermission
   , requestPermission
   )
 import Hatter.Widget
@@ -172,6 +173,9 @@ data BeaconStatus
 -- share one handle.
 data AppState = AppState
   { statePage :: IORef AppPage
+  , statePermissionProbed :: IORef Bool
+    -- ^ Whether the first render already asked the platform if the
+    -- permissions are granted (the probe must run exactly once).
   , stateBeacons :: IORef [DiscoveredBeacon]
   , stateSeenAddresses :: IORef (Set Text)
   , stateAdvPeriodInput :: IORef Text
@@ -236,6 +240,7 @@ otaAppMain = do
 newAppState :: IO AppState
 newAppState = do
   page <- newIORef PermissionPage
+  permissionProbed <- newIORef False
   beacons <- newIORef []
   seen <- newIORef Set.empty
   advPeriod <- newIORef "1000"
@@ -250,6 +255,7 @@ newAppState = do
   redraw <- newIORef (pure ())
   pure AppState
     { statePage = page
+    , statePermissionProbed = permissionProbed
     , stateBeacons = beacons
     , stateSeenAddresses = seen
     , stateAdvPeriodInput = advPeriod
@@ -642,11 +648,38 @@ appView appState
         onCheckAdapter onRequestPerms onStartScan onStopScan onConfigureAll
         onPeriodChange onThresholdChange onReportUrlChange = do
   page <- readIORef (statePage appState)
-  case page of
+  resolvedPage <- case page of
+    PermissionPage -> resolvePermissionPage appState
+    ScannerPage -> pure ScannerPage
+  case resolvedPage of
     PermissionPage -> permissionPageView appState onRequestPerms
     ScannerPage -> scannerPageView appState
       onCheckAdapter onStartScan onStopScan onConfigureAll
       onPeriodChange onThresholdChange onReportUrlChange
+
+-- | On the first render, ask the platform whether both permissions
+-- are already granted and skip the permission page entirely if so.
+-- Probed at render time because the platform bridges are only
+-- registered right before the first render runs (jni_bridge.c wires
+-- them immediately before calling the view), and probed exactly once
+-- so a denial does not re-run the check on every redraw.
+resolvePermissionPage :: AppState -> IO AppPage
+resolvePermissionPage appState = do
+  alreadyProbed <- readIORef (statePermissionProbed appState)
+  if alreadyProbed
+    then pure PermissionPage
+    else do
+      writeIORef (statePermissionProbed appState) True
+      bluetoothStatus <- checkPermission PermissionBluetooth
+      locationStatus <- checkPermission PermissionLocation
+      case (bluetoothStatus, locationStatus) of
+        (PermissionGranted, PermissionGranted) -> do
+          platformLog "permissions already granted, skipping the permission page"
+          writeIORef (statePage appState) ScannerPage
+          pure ScannerPage
+        (PermissionDenied, PermissionDenied) -> pure PermissionPage
+        (PermissionDenied, PermissionGranted) -> pure PermissionPage
+        (PermissionGranted, PermissionDenied) -> pure PermissionPage
 
 -- | The one-time permission page; 'continuePastPermissions' replaces
 -- it with the scanner page once both permissions are granted.
@@ -752,18 +785,20 @@ rateColor verdict = case verdict of
   RateMatching -> Just (Color 0x2E 0x7D 0x32 0xFF)
   RateDeviating -> Just (Color 0xC6 0x28 0x28 0xFF)
 
--- | One row per discovered beacon, colored by its rate verdict.
+-- | One row per discovered beacon, its texts colored by the rate
+-- verdict.
 beaconRow :: Either Text AdvPeriodMs -> DiscoveredBeacon -> Widget
 beaconRow expectedPeriod beacon =
   let target = beaconTarget beacon
+      color = rateColor (rateVerdict expectedPeriod (beaconIntervalMs beacon))
       batteryText = case beaconBattery beacon of
         Just percent -> " | " <> pack (show percent) <> "%"
         Nothing -> ""
       rateText = case beaconIntervalMs beacon of
-        Just intervalMs -> " | ~" <> pack (show intervalMs) <> " ms"
+        Just intervalMs -> " | every ~" <> pack (show intervalMs) <> " ms"
         Nothing -> ""
       statusText = case beaconStatus beacon of
-        StatusFound -> "found"
+        StatusFound -> "not yet configured"
         StatusConfiguring -> "configuring..."
         StatusConfigured success ->
           "set to " <> pack (show (unAdvPeriodMs (successAppliedPeriod success))) <> " ms"
@@ -774,19 +809,26 @@ beaconRow expectedPeriod beacon =
       reportText = case beaconReportNote beacon of
         Just note -> " | " <> note
         Nothing -> ""
-      rowWidget = column
-        [ row
-            [ text (targetName target)
-            , text (" | " <> unBleDeviceAddress (targetAddress target))
-            , text (" | RSSI: " <> pack (show (beaconRssi beacon)))
-            -- Battery and rate are separate nodes so the emulator
-            -- test can exact-match the deterministic battery text
-            -- while the measured rate varies.
-            , text batteryText
-            , text rateText
-            ]
-        , text ("   " <> statusText <> reportText)
+  in column
+    [ row
+        [ rowText color (targetName target)
+        , rowText color (" | " <> unBleDeviceAddress (targetAddress target))
+        , rowText color (" | RSSI: " <> pack (show (beaconRssi beacon)))
+        -- Battery and rate are separate nodes so the emulator
+        -- test can exact-match the deterministic battery text
+        -- while the measured rate varies.
+        , rowText color batteryText
+        , rowText color rateText
         ]
-  in case rateColor (rateVerdict expectedPeriod (beaconIntervalMs beacon)) of
-    Nothing -> rowWidget
-    Just color -> Styled defaultStyle { wsTextColor = Just color } rowWidget
+    , rowText color ("   " <> statusText <> reportText)
+    ]
+
+-- | A row text fragment carrying the rate color when there is one.
+-- The color must sit on each text node individually: a WidgetStyle
+-- applies only to the single node it wraps (Hatter.Render.applyStyle
+-- sets the property on that node), so coloring the row's column
+-- would set text color on a container and change nothing visible.
+rowText :: Maybe Color -> Text -> Widget
+rowText color content = case color of
+  Nothing -> text content
+  Just chosen -> Styled defaultStyle { wsTextColor = Just chosen } (text content)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -30,7 +30,6 @@ import Hatter.Widget
   , TextConfig(..)
   , TextInputConfig(..)
   , Widget(..)
-  , WidgetStyle(..)
   )
 import KBeacon.Configure (BeaconTarget(..))
 import KBeacon.Json
@@ -697,20 +696,25 @@ widgetTexts = \case
   Styled _ inner -> widgetTexts inner
   Animated _ inner -> widgetTexts inner
 
--- | Every text-color override applied in a widget tree, in tree
--- order; how the rate coloring is observed.
+-- | Every text color carried by glyph-bearing widgets, in tree
+-- order; how the rate coloring is observed. Colors live on the
+-- configs themselves since hatter #242.
 widgetTextColors :: Widget -> [Color]
 widgetTextColors = \case
-  Text _ -> []
-  Button _ -> []
-  TextInput _ -> []
+  Text config -> case tcTextColor config of
+    Just color -> [color]
+    Nothing -> []
+  Button config -> case bcTextColor config of
+    Just color -> [color]
+    Nothing -> []
+  TextInput config -> case tiTextColor config of
+    Just color -> [color]
+    Nothing -> []
   Column settings -> concatMap (widgetTextColors . liWidget) (lsWidgets settings)
   Row settings -> concatMap (widgetTextColors . liWidget) (lsWidgets settings)
   Stack items -> concatMap (widgetTextColors . liWidget) items
   Image _ -> []
   WebView _ -> []
   MapView _ -> []
-  Styled style inner -> case wsTextColor style of
-    Just color -> color : widgetTextColors inner
-    Nothing -> widgetTextColors inner
+  Styled _ inner -> widgetTextColors inner
   Animated _ inner -> widgetTextColors inner

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -10,6 +10,7 @@ module Main where
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
+import Data.List (nub)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Hatter (newActionState, runActionM, createAction, createOnChange)
@@ -435,7 +436,7 @@ scanUiTests = testGroup "scan signal to ui"
       beaconsAfterThree <- readIORef (stateBeacons appState)
       assertEqual "smoothed three parts old, one part new"
         [Just 1050] (map beaconIntervalMs beaconsAfterThree)
-  , testCase "the measured rate colors the row against the expected interval" $ do
+  , testCase "the measured rate colors every text of the row" $ do
       (appState, _) <- newScannerAppState
       writeIORef (stateAdvPeriodInput appState) "1000"
       onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
@@ -443,15 +444,20 @@ scanUiTests = testGroup "scan signal to ui"
       assertEqual "no color before a measurement" 0 (length colorsBefore)
       onScanResultAt 11 appState defaultRssiThreshold androidKBeaconSignal
       colorsMatching <- fmap widgetTextColors (renderedAppWidget appState)
-      assertEqual "one colored row at the expected rate" 1 (length colorsMatching)
+      -- Every text node of the row must carry the color itself: a
+      -- style on the row's container would change nothing visible.
+      assertEqual "all six row texts colored at the expected rate"
+        6 (length colorsMatching)
+      assertEqual "one uniform color" 1 (length (nub colorsMatching))
       (slowState, _) <- newScannerAppState
       writeIORef (stateAdvPeriodInput slowState) "1000"
       onScanResultAt 10 slowState defaultRssiThreshold androidKBeaconSignal
       onScanResultAt 15 slowState defaultRssiThreshold androidKBeaconSignal
       colorsDeviating <- fmap widgetTextColors (renderedAppWidget slowState)
-      assertEqual "one colored row at a deviating rate" 1 (length colorsDeviating)
+      assertEqual "all six row texts colored at a deviating rate"
+        6 (length colorsDeviating)
       assertBool "matching and deviating rates color differently"
-        (colorsMatching /= colorsDeviating)
+        (nub colorsMatching /= nub colorsDeviating)
   , testCase "rateVerdict tolerates jitter but flags another period" $ do
       assertEqual "exact" RateMatching
         (rateVerdict (validateAdvPeriod 1000) (Just 1000))
@@ -545,8 +551,21 @@ scanUiTests = testGroup "scan signal to ui"
         (map (targetMac . beaconTarget) beacons)
       repaintCount <- readIORef repaints
       assertEqual "repainted for the named result" 1 repaintCount
+  , testCase "granted permissions skip the permission page at first render" $ do
+      -- The desktop permission stub reports granted, standing in for
+      -- a device where both permissions were kept from an earlier
+      -- run: the first render must land directly on the scanner.
+      (appState, _) <- newCountingAppState
+      texts <- renderedAppTexts appState
+      assertBool "scanner shown immediately"
+        (any (Text.isInfixOf "Start Scan") texts)
+      page <- readIORef (statePage appState)
+      assertEqual "page flipped by the probe" ScannerPage page
   , testCase "the app opens on the permission page and grants move it on" $ do
       (appState, _) <- newCountingAppState
+      -- Pretend the probe already ran and did not grant (the desktop
+      -- stub always grants, which the skip test above covers).
+      writeIORef (statePermissionProbed appState) True
       textsBefore <- renderedAppTexts appState
       assertBool "permission button shown"
         (any (Text.isInfixOf "Request Permissions") textsBefore)
@@ -562,6 +581,7 @@ scanUiTests = testGroup "scan signal to ui"
         (not (any (Text.isInfixOf "Request Permissions") textsAfter))
   , testCase "a denied permission keeps the permission page up" $ do
       (appState, _) <- newCountingAppState
+      writeIORef (statePermissionProbed appState) True
       continuePastPermissions appState PermissionGranted PermissionDenied
       page <- readIORef (statePage appState)
       assertEqual "page unchanged" PermissionPage page

--- a/test/android/kbeacon.sh
+++ b/test/android/kbeacon.sh
@@ -6,9 +6,9 @@
 # under various bluetooth signals. Ordered to use only two scans (see
 # the scan-rate note further down):
 #
-#   Phase 1  render + permissions + adapter: app renders its
-#            permission page, granting moves it to the scanner page,
-#            adapter reports on.
+#   Phase 1  render + permissions + adapter: permissions are
+#            pre-granted, so the app skips its permission page and
+#            renders the scanner directly; adapter reports on.
 #   Phase 2  weak signal: threshold 100 dBm (above netsim's fixed +20
 #            RSSI), the beacon's advertisement is ignored and the list
 #            stays empty (RSSI proximity filter).
@@ -184,15 +184,13 @@ wait_for_logcat "kbeacon-ota starting" 30 || true
 collect_logcat "kbeacon"
 assert_logcat "$LOGCAT_FILE" "kbeacon-ota starting" "app main ran"
 
-# The app opens on the permission page; the permissions were granted
-# via pm above, so tapping Request Permissions gets granted callbacks
-# and the app moves itself to the scanner page.
-tap_button "Request Permissions" || echo "WARNING: could not tap Request Permissions"
-wait_for_logcat "permissions granted" 20 || true
+# The permissions were granted via pm above, so the app probes them
+# on its first render and skips the permission page entirely.
+wait_for_logcat "permissions already granted" 20 || true
 LOGCAT_PERMS="$WORK_DIR/kbeacon_perms.txt"
 "$ADB" -s "$EMULATOR_SERIAL" logcat -d '*:I' > "$LOGCAT_PERMS" 2>&1 || true
-assert_logcat "$LOGCAT_PERMS" "permissions granted" \
-    "permission page advanced to the scanner"
+assert_logcat "$LOGCAT_PERMS" "permissions already granted, skipping the permission page" \
+    "permission page skipped when everything is granted"
 
 tap_button "Check Adapter" || echo "WARNING: could not tap Check Adapter"
 wait_for_logcat "BLE adapter: BleAdapterOn" 20 || true


### PR DESCRIPTION
Field findings from testing the merged #5:

## Row colors actually render now

The rate coloring never showed on-device: `WidgetStyle` properties apply to the single node they wrap (`Hatter.Render.applyStyle` sets the property on that node), so styling the row's *column* set text color on a LinearLayout, a silent no-op. Every text node of the row now carries the color itself. The color test asserts all six row texts are colored and was verified to fail against the old container styling. Colors remain: green when the measured advertisement rate matches the expected interval input within 25%, red when it deviates, uncolored until a rate is measured (second advertisement).

## Wording

- `~1024 ms` read as meters/second: now renders as `every ~1024 ms` (the measured advertising interval).
- `found` now reads `not yet configured`.

## Permission page skips when everything is granted

The first render probes `checkPermission` for both permissions (safe: jni_bridge.c registers the platform bridges immediately before invoking the first render) exactly once, and lands directly on the scanner when both are granted. A denial keeps the page as before. The emulator test now asserts the skip (CI pre-grants via `pm`); the permission-page unit tests pre-mark the probe since the desktop stub always grants.

65 tests green, zero warnings, shellcheck clean; both new behaviours sabotage-verified to fail their tests alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)