### PR TITLE
Beacon table: fixed-width aligned columns, strongest signal on top

### DIFF
--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,14 +4,14 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace",
+        "owner": "jappeace-sloth",
         "repo": "hatter"
       },
-      "branch": "master",
+      "branch": "feat/width-style-property",
       "submodules": false,
-      "revision": "2f6d6277800693cccaba9768ca9d0ed99000de39",
-      "url": "https://github.com/jappeace/hatter/archive/2f6d6277800693cccaba9768ca9d0ed99000de39.tar.gz",
-      "hash": "sha256-9p92EFoBDUkDC3uSh6/7lqSDFNO8N/TbVuAl+1bCybo="
+      "revision": "a0185b253803fc854941d56f7053617bdbe78d89",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/a0185b253803fc854941d56f7053617bdbe78d89.tar.gz",
+      "hash": "sha256-1G3MGE8+VBxI5xnbCy2TPqsN4Aptg4AoU+6LWzf+lNA="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -4,14 +4,14 @@
       "type": "Git",
       "repository": {
         "type": "GitHub",
-        "owner": "jappeace-sloth",
+        "owner": "jappeace",
         "repo": "hatter"
       },
-      "branch": "feat/width-style-property",
+      "branch": "master",
       "submodules": false,
-      "revision": "cea0a8022d0aa19af469e74d56c35900a3a0c612",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/cea0a8022d0aa19af469e74d56c35900a3a0c612.tar.gz",
-      "hash": "sha256-DxGL2f7GSo4vEvfxGw8T/df7MZV/8gN+HHTZKBx+Kcw="
+      "revision": "a20ad8e84841b29fb8c94b36b37154efeed594dc",
+      "url": "https://github.com/jappeace/hatter/archive/a20ad8e84841b29fb8c94b36b37154efeed594dc.tar.gz",
+      "hash": "sha256-O4eoiudKphOf8W1N44+CW2h/AORWhT7kKTsY7940J1k="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/nix/sources/sources.json
+++ b/nix/sources/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "feat/width-style-property",
       "submodules": false,
-      "revision": "a0185b253803fc854941d56f7053617bdbe78d89",
-      "url": "https://github.com/jappeace-sloth/hatter/archive/a0185b253803fc854941d56f7053617bdbe78d89.tar.gz",
-      "hash": "sha256-1G3MGE8+VBxI5xnbCy2TPqsN4Aptg4AoU+6LWzf+lNA="
+      "revision": "cea0a8022d0aa19af469e74d56c35900a3a0c612",
+      "url": "https://github.com/jappeace-sloth/hatter/archive/cea0a8022d0aa19af469e74d56c35900a3a0c612.tar.gz",
+      "hash": "sha256-DxGL2f7GSo4vEvfxGw8T/df7MZV/8gN+HHTZKBx+Kcw="
     },
     "mobile-core-tools": {
       "type": "Git",

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -111,10 +111,12 @@ import Hatter.Widget
   , Widget(..)
   , coloredText
   , column
+  , defaultStyle
   , row
   , scrollColumn
   , text
   , button
+  , wsWidth
   )
 import KBeacon.Configure
   ( BeaconOutcome(..)
@@ -752,15 +754,39 @@ scannerPageView appState
         (sortBy (comparing (Down . beaconRssi)) beacons))
     ])
 
--- | The table's column headers.
+-- | The table's column headers, sharing the row cells' widths so the
+-- columns align (hatter #245).
 beaconTableHeader :: Widget
 beaconTableHeader = row
-  [ text "serial"
-  , text " | rssi"
-  , text " | battery"
-  , text " | rate (ms)"
-  , text " | status"
+  [ tableCell serialColumnWidth Nothing "serial"
+  , tableCell rssiColumnWidth Nothing "rssi"
+  , tableCell batteryColumnWidth Nothing "battery"
+  , tableCell rateColumnWidth Nothing "rate (ms)"
+  , tableCell Nothing Nothing "status"
   ]
+
+-- | Fixed column widths in platform pixels (hatter's wsWidth unit,
+-- like wsPadding); the status column stays content-sized. Chosen for
+-- the emulator's 1080 px portrait width and roomy on phones.
+serialColumnWidth :: Maybe Double
+serialColumnWidth = Just 220
+
+rssiColumnWidth :: Maybe Double
+rssiColumnWidth = Just 130
+
+batteryColumnWidth :: Maybe Double
+batteryColumnWidth = Just 170
+
+rateColumnWidth :: Maybe Double
+rateColumnWidth = Just 200
+
+-- | One table cell: optionally fixed-width, optionally colored.
+tableCell :: Maybe Double -> Maybe Color -> Text -> Widget
+tableCell width color content =
+  let inner = rowText color content
+  in case width of
+    Nothing -> inner
+    Just cellWidth -> Styled defaultStyle { wsWidth = Just cellWidth } inner
 
 -- | How a beacon's measured advertisement interval relates to the
 -- expected interval input.
@@ -820,11 +846,11 @@ beaconTableRow expectedPeriod beacon =
         Just note -> " | " <> note
         Nothing -> ""
   in row
-    [ rowText color (beaconSerial beacon)
-    , rowText color (" | " <> pack (show (beaconRssi beacon)))
-    , rowText color (" | " <> batteryCell)
-    , rowText color (" | " <> beaconRateCell beacon)
-    , rowText color (" | " <> statusText <> reportText)
+    [ tableCell serialColumnWidth color (beaconSerial beacon)
+    , tableCell rssiColumnWidth color (pack (show (beaconRssi beacon)))
+    , tableCell batteryColumnWidth color batteryCell
+    , tableCell rateColumnWidth color (beaconRateCell beacon)
+    , tableCell Nothing color (statusText <> reportText)
     ]
 
 -- | A beacon's serial number: the hex digits of its MAC's low three

--- a/src/KBeacon/OtaApp.hs
+++ b/src/KBeacon/OtaApp.hs
@@ -52,6 +52,8 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as ByteString
 import Data.Char (intToDigit, toUpper)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef, modifyIORef')
+import Data.List (sortBy)
+import Data.Ord (Down(..), comparing)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text, pack)
@@ -745,8 +747,20 @@ scannerPageView appState
     , text ("Status: " <> statusLine)
     , text ("Scanning: " <> (if scanning then "yes" else "no")
         <> " | " <> pack (show (length beacons)) <> " device(s) found")
-    , scrollColumn (map (beaconRow expectedPeriod) (reverse beacons))
+    , beaconTableHeader
+    , scrollColumn (map (beaconTableRow expectedPeriod)
+        (sortBy (comparing (Down . beaconRssi)) beacons))
     ])
+
+-- | The table's column headers.
+beaconTableHeader :: Widget
+beaconTableHeader = row
+  [ text "serial"
+  , text " | rssi"
+  , text " | battery"
+  , text " | rate (ms)"
+  , text " | status"
+  ]
 
 -- | How a beacon's measured advertisement interval relates to the
 -- expected interval input.
@@ -787,43 +801,58 @@ rateColor verdict = case verdict of
   RateMatching -> Just (Color 0x2E 0x7D 0x32 0xFF)
   RateDeviating -> Just (Color 0xC6 0x28 0x28 0xFF)
 
--- | One row per discovered beacon, its texts colored by the rate
--- verdict.
-beaconRow :: Either Text AdvPeriodMs -> DiscoveredBeacon -> Widget
-beaconRow expectedPeriod beacon =
-  let target = beaconTarget beacon
-      color = rateColor (rateVerdict expectedPeriod (beaconIntervalMs beacon))
-      batteryText = case beaconBattery beacon of
-        Just percent -> " | " <> pack (show percent) <> "%"
-        Nothing -> ""
-      rateText = case beaconIntervalMs beacon of
-        Just intervalMs -> " | every ~" <> pack (show intervalMs) <> " ms"
-        Nothing -> ""
+-- | One table row per discovered beacon: serial, RSSI, battery, the
+-- device's rate and the status, each cell its own node (the emulator
+-- test exact-matches the deterministic cells) and colored by the
+-- rate verdict.
+beaconTableRow :: Either Text AdvPeriodMs -> DiscoveredBeacon -> Widget
+beaconTableRow expectedPeriod beacon =
+  let color = rateColor (rateVerdict expectedPeriod (beaconIntervalMs beacon))
+      batteryCell = case beaconBattery beacon of
+        Just percent -> pack (show percent)
+        Nothing -> "?"
       statusText = case beaconStatus beacon of
         StatusFound -> "not yet configured"
         StatusConfiguring -> "configuring..."
-        StatusConfigured success ->
-          "set to " <> pack (show (unAdvPeriodMs (successAppliedPeriod success))) <> " ms"
-            <> (case successBatteryPercent success of
-                 Just percent -> ", battery " <> pack (show percent) <> "%"
-                 Nothing -> "")
+        StatusConfigured _ -> "configured"
         StatusFailed failure -> "failed: " <> failure
       reportText = case beaconReportNote beacon of
         Just note -> " | " <> note
         Nothing -> ""
-  in column
-    [ row
-        [ rowText color (targetName target)
-        , rowText color (" | " <> unBleDeviceAddress (targetAddress target))
-        , rowText color (" | RSSI: " <> pack (show (beaconRssi beacon)))
-        -- Battery and rate are separate nodes so the emulator
-        -- test can exact-match the deterministic battery text
-        -- while the measured rate varies.
-        , rowText color batteryText
-        , rowText color rateText
-        ]
-    , rowText color ("   " <> statusText <> reportText)
+  in row
+    [ rowText color (beaconSerial beacon)
+    , rowText color (" | " <> pack (show (beaconRssi beacon)))
+    , rowText color (" | " <> batteryCell)
+    , rowText color (" | " <> beaconRateCell beacon)
+    , rowText color (" | " <> statusText <> reportText)
     ]
+
+-- | A beacon's serial number: the hex digits of its MAC's low three
+-- bytes, the same digits factory names carry after their "KBPro-"
+-- prefix, so renamed beacons show a stable serial too. Falls back to
+-- the name's dash-suffix when no MAC is known.
+beaconSerial :: DiscoveredBeacon -> Text
+beaconSerial beacon = case targetMac (beaconTarget beacon) of
+  Just mac -> Text.concat
+    (map formatMacByte (ByteString.unpack (ByteString.drop 3 (unBeaconMac mac))))
+  Nothing -> Text.takeWhileEnd (/= '-') (targetName (beaconTarget beacon))
+
+-- | The rate cell: the exact period once this beacon was configured,
+-- the measured estimate (tilde) while only observed, "?" until a
+-- second advertisement gives a measurement.
+beaconRateCell :: DiscoveredBeacon -> Text
+beaconRateCell beacon = case beaconStatus beacon of
+  StatusConfigured success ->
+    pack (show (unAdvPeriodMs (successAppliedPeriod success)))
+  StatusFound -> measuredRateCell (beaconIntervalMs beacon)
+  StatusConfiguring -> measuredRateCell (beaconIntervalMs beacon)
+  StatusFailed _ -> measuredRateCell (beaconIntervalMs beacon)
+
+-- | The measured half of 'beaconRateCell'.
+measuredRateCell :: Maybe Int -> Text
+measuredRateCell interval = case interval of
+  Just intervalMs -> "~" <> pack (show intervalMs)
+  Nothing -> "?"
 
 -- | A row text fragment carrying the rate color when there is one.
 -- Text color lives on the text config itself (hatter #242), so it

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -415,21 +415,32 @@ scanUiTests = testGroup "scan signal to ui"
       assertBool "device count reflects the discovery"
         (any (Text.isInfixOf "1 device(s) found") textsAfter)
   , testCase "the table sorts the strongest signal on top" $ do
+      -- Insertion order middle, strong, weak: the prepend accumulator
+      -- holds [weak, strong, middle] and its reverse [middle, strong,
+      -- weak], so neither an unsorted nor a merely-reversed list can
+      -- pass; only sorting by RSSI puts strong, middle, weak.
       (appState, _) <- newScannerAppState
       onScanResultAt 10 appState defaultRssiThreshold
-        androidKBeaconSignal { bsrRssi = -45 }
+        androidKBeaconSignal { bsrRssi = -40 }
       onScanResultAt 11 appState defaultRssiThreshold BleScanResult
         { bsrDeviceName = "KBPro-F4F5F6"
         , bsrDeviceAddress = BleDeviceAddress "FC:57:29:F4:F5:F6"
         , bsrRssi = -30
         , bsrAdvertisement = Right emptyBleAdvertisement
         }
+      onScanResultAt 12 appState defaultRssiThreshold BleScanResult
+        { bsrDeviceName = "KBPro-112233"
+        , bsrDeviceAddress = BleDeviceAddress "BC:57:29:11:22:33"
+        , bsrRssi = -45
+        , bsrAdvertisement = Right emptyBleAdvertisement
+        }
       texts <- renderedAppTexts appState
       let position serial = length (takeWhile (/= serial) texts)
-      assertBool "both serials rendered"
-        (elem "F4F5F6" texts && elem "4D5E6F" texts)
-      assertBool "stronger signal renders first"
-        (position "F4F5F6" < position "4D5E6F")
+      assertBool "all three serials rendered"
+        (elem "F4F5F6" texts && elem "4D5E6F" texts && elem "112233" texts)
+      assertBool "descending RSSI order"
+        (position "F4F5F6" < position "4D5E6F"
+          && position "4D5E6F" < position "112233")
   , testCase "a repeated advertisement refreshes the row, not duplicates it" $ do
       (appState, repaints) <- newScannerAppState
       onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -403,17 +403,33 @@ scanUiTests = testGroup "scan signal to ui"
       (appState, repaints) <- newScannerAppState
       textsBefore <- renderedAppTexts appState
       assertBool "beacon must not be listed before the signal"
-        (not (any (Text.isInfixOf "KBPro-4D5E6F") textsBefore))
+        (not (any (Text.isInfixOf "4D5E6F") textsBefore))
       onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
       repaintCount <- readIORef repaints
       assertEqual "repaints after the signal" 1 repaintCount
       textsAfter <- renderedAppTexts appState
-      assertBool "beacon row rendered after the signal"
-        (any (Text.isInfixOf "KBPro-4D5E6F") textsAfter)
-      assertBool "battery from the advertisement rendered"
-        (any (Text.isInfixOf "85%") textsAfter)
+      assertBool "serial cell rendered after the signal"
+        (elem "4D5E6F" textsAfter)
+      assertBool "battery cell from the advertisement rendered"
+        (elem " | 85" textsAfter)
       assertBool "device count reflects the discovery"
         (any (Text.isInfixOf "1 device(s) found") textsAfter)
+  , testCase "the table sorts the strongest signal on top" $ do
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold
+        androidKBeaconSignal { bsrRssi = -45 }
+      onScanResultAt 11 appState defaultRssiThreshold BleScanResult
+        { bsrDeviceName = "KBPro-F4F5F6"
+        , bsrDeviceAddress = BleDeviceAddress "FC:57:29:F4:F5:F6"
+        , bsrRssi = -30
+        , bsrAdvertisement = Right emptyBleAdvertisement
+        }
+      texts <- renderedAppTexts appState
+      let position serial = length (takeWhile (/= serial) texts)
+      assertBool "both serials rendered"
+        (elem "F4F5F6" texts && elem "4D5E6F" texts)
+      assertBool "stronger signal renders first"
+        (position "F4F5F6" < position "4D5E6F")
   , testCase "a repeated advertisement refreshes the row, not duplicates it" $ do
       (appState, repaints) <- newScannerAppState
       onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
@@ -445,16 +461,16 @@ scanUiTests = testGroup "scan signal to ui"
       colorsMatching <- fmap widgetTextColors (renderedAppWidget appState)
       -- Every text node of the row must carry the color itself: a
       -- style on the row's container would change nothing visible.
-      assertEqual "all six row texts colored at the expected rate"
-        6 (length colorsMatching)
+      assertEqual "all five row cells colored at the expected rate"
+        5 (length colorsMatching)
       assertEqual "one uniform color" 1 (length (nub colorsMatching))
       (slowState, _) <- newScannerAppState
       writeIORef (stateAdvPeriodInput slowState) "1000"
       onScanResultAt 10 slowState defaultRssiThreshold androidKBeaconSignal
       onScanResultAt 15 slowState defaultRssiThreshold androidKBeaconSignal
       colorsDeviating <- fmap widgetTextColors (renderedAppWidget slowState)
-      assertEqual "all six row texts colored at a deviating rate"
-        6 (length colorsDeviating)
+      assertEqual "all five row cells colored at a deviating rate"
+        5 (length colorsDeviating)
       assertBool "matching and deviating rates color differently"
         (nub colorsMatching /= nub colorsDeviating)
   , testCase "rateVerdict tolerates jitter but flags another period" $ do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -30,6 +30,7 @@ import Hatter.Widget
   , TextConfig(..)
   , TextInputConfig(..)
   , Widget(..)
+  , wsWidth
   )
 import KBeacon.Configure (BeaconTarget(..))
 import KBeacon.Json
@@ -411,9 +412,26 @@ scanUiTests = testGroup "scan signal to ui"
       assertBool "serial cell rendered after the signal"
         (elem "4D5E6F" textsAfter)
       assertBool "battery cell from the advertisement rendered"
-        (elem " | 85" textsAfter)
+        (elem "85" textsAfter)
       assertBool "device count reflects the discovery"
         (any (Text.isInfixOf "1 device(s) found") textsAfter)
+  , testCase "header and row cells share column widths" $ do
+      (appState, _) <- newScannerAppState
+      onScanResultAt 10 appState defaultRssiThreshold androidKBeaconSignal
+      onScanResultAt 11 appState defaultRssiThreshold BleScanResult
+        { bsrDeviceName = "KBPro-F4F5F6"
+        , bsrDeviceAddress = BleDeviceAddress "FC:57:29:F4:F5:F6"
+        , bsrRssi = -30
+        , bsrAdvertisement = Right emptyBleAdvertisement
+        }
+      widths <- fmap widgetWidths (renderedAppWidget appState)
+      assertEqual "four fixed columns in header and both rows"
+        12 (length widths)
+      let columnsOf index = take 4 (drop (index * 4) widths)
+      assertEqual "row one aligns with the header"
+        (columnsOf 0) (columnsOf 1)
+      assertEqual "row two aligns with the header"
+        (columnsOf 0) (columnsOf 2)
   , testCase "the table sorts the strongest signal on top" $ do
       -- Insertion order middle, strong, weak: the prepend accumulator
       -- holds [weak, strong, middle] and its reverse [middle, strong,
@@ -722,6 +740,24 @@ widgetTexts = \case
   MapView _ -> []
   Styled _ inner -> widgetTexts inner
   Animated _ inner -> widgetTexts inner
+
+-- | Every fixed width applied via Styled wrappers, in tree order;
+-- how column alignment is observed.
+widgetWidths :: Widget -> [Double]
+widgetWidths = \case
+  Text _ -> []
+  Button _ -> []
+  TextInput _ -> []
+  Column settings -> concatMap (widgetWidths . liWidget) (lsWidgets settings)
+  Row settings -> concatMap (widgetWidths . liWidget) (lsWidgets settings)
+  Stack items -> concatMap (widgetWidths . liWidget) items
+  Image _ -> []
+  WebView _ -> []
+  MapView _ -> []
+  Styled style inner -> case wsWidth style of
+    Just width -> width : widgetWidths inner
+    Nothing -> widgetWidths inner
+  Animated _ inner -> widgetWidths inner
 
 -- | Every text color carried by glyph-bearing widgets, in tree
 -- order; how the rate coloring is observed. Colors live on the

--- a/test/android/kbeacon.sh
+++ b/test/android/kbeacon.sh
@@ -248,7 +248,7 @@ fi
 assert_ui_text "Scanning: yes | 1 device(s) found" "UI shows one discovered device"
 # Battery 85 travels in the simulated 0x2080 service data and must
 # show in the table's battery cell without connecting.
-assert_ui_text " | 85" "battery shown from the advertisement"
+assert_ui_text "85" "battery shown from the advertisement"
 
 # Configure All stops the scan internally and reuses the list above,
 # so no third scan is started.

--- a/test/android/kbeacon.sh
+++ b/test/android/kbeacon.sh
@@ -247,8 +247,8 @@ else
 fi
 assert_ui_text "Scanning: yes | 1 device(s) found" "UI shows one discovered device"
 # Battery 85 travels in the simulated 0x2080 service data and must
-# show on the row without connecting.
-assert_ui_text " | 85%" "battery percent shown from the advertisement"
+# show in the table's battery cell without connecting.
+assert_ui_text " | 85" "battery shown from the advertisement"
 
 # Configure All stops the scan internally and reuses the list above,
 # so no third scan is started.


### PR DESCRIPTION
The table work that landed on this branch after #6 merged (its commits were orphaned by the merge timing; this PR carries them):

- The beacon list is an actual table: header row plus one row per beacon with serial (MAC's low three hex bytes, stable for renamed beacons), bare RSSI, bare battery, the device's rate (exact once configured, `~estimate` while observed, `?` before a measurement) and status.
- Serial, RSSI, battery and rate columns share **fixed widths** between the header and every row via hatter's new `wsWidth` (jappeace/hatter#246, resolving #245, built for this feature); a test walks the rendered widths and asserts each row's columns equal the header's.
- Rows sort by RSSI, strongest on top; the sort test uses a three-beacon ordering that fails both the no-sort and reversed-list mutants (both verified).

Pins hatter at the #246 branch head; repoint to master after #246 merges. Merge order: hatter#246, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)