### PR TITLE
Add setup-ios.sh for one-command device installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ result
 result-*
 cabal.project.local
 __pycache__/
+ios-project/

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ nix-build nix/ios-app.nix              # staged Xcode project (simulator)
 nix-build nix/ios-device-app.nix       # staged Xcode project (device)
 ```
 
-Or build, sign and install on a connected device in one go:
+Or stage a ready-to-open Xcode project for a connected device
+(signing and installing happen from the Xcode GUI):
 
 ```
 ./setup-ios.sh
+open ios-project/Hatter.xcodeproj
 ```
 
 iOS caveat: CoreBluetooth never exposes MAC addresses, but KBeacon

--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ The iOS library and Xcode staging build on a Mac:
 ```
 nix-build nix/ios.nix                  # device library
 nix-build nix/ios.nix --arg simulator true
-nix-build nix/ios-app.nix              # staged Xcode project
+nix-build nix/ios-app.nix              # staged Xcode project (simulator)
+nix-build nix/ios-device-app.nix       # staged Xcode project (device)
+```
+
+Or build, sign and install on a connected device in one go:
+
+```
+./setup-ios.sh
 ```
 
 iOS caveat: CoreBluetooth never exposes MAC addresses, but KBeacon

--- a/nix/ios-device-app.nix
+++ b/nix/ios-device-app.nix
@@ -10,6 +10,11 @@ let
   lib = import "${sources.hatter}/nix/lib.nix" { inherit sources; };
   iosLib = import ./ios.nix { inherit sources; simulator = false; };
 in
+# Despite its name, hatter's mkSimulatorApp is just the Xcode project
+# stager: it copies Swift sources, project.yml and the given static
+# library. Device vs simulator is decided by which library ios.nix
+# builds (simulator = false above). prrrrrrrrr's ios-device-app.nix
+# uses it the same way.
 lib.mkSimulatorApp {
   inherit iosLib;
   iosSrc = "${sources.hatter}/ios";

--- a/nix/ios-device-app.nix
+++ b/nix/ios-device-app.nix
@@ -1,0 +1,17 @@
+# iOS device app: stages hatter's Xcode project with the pre-built
+# kbeacon-ota Haskell library, targeting a real iOS device.
+#
+# Output: $out/share/ios/ containing project.yml, Swift sources, and
+# the static library ready for xcodebuild.
+#
+# Usage (on a Mac): nix-build nix/ios-device-app.nix
+{ sources ? import ./sources }:
+let
+  lib = import "${sources.hatter}/nix/lib.nix" { inherit sources; };
+  iosLib = import ./ios.nix { inherit sources; simulator = false; };
+in
+lib.mkSimulatorApp {
+  inherit iosLib;
+  iosSrc = "${sources.hatter}/ios";
+  name = "kbeacon-ota-ios-device";
+}

--- a/setup-ios.sh
+++ b/setup-ios.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Set up kbeacon-ota on a connected iOS device.
+# Requires macOS with Xcode and Nix installed.
+#
+# Usage:
+#   ./setup-ios.sh
+
+set -euo pipefail
+
+result=$(nix-build nix/ios-device-app.nix)
+
+# Copy nix output to a writable directory (nix store is read-only)
+workdir=$(mktemp -d)
+cp -r "$result/share/ios/." "$workdir/"
+chmod -R u+w "$workdir"
+
+# Generate Xcode project and build
+cd "$workdir"
+xcodegen generate
+
+# Auto-discover Apple Development team ID from keychain
+TEAM_ID=$(security find-identity -v -p codesigning \
+  | grep "Apple Development" \
+  | head -1 \
+  | sed 's/.*(\(.*\)).*/\1/')
+[ -z "$TEAM_ID" ] && echo "No Apple Development signing identity found in keychain" && exit 1
+echo "Using team ID: $TEAM_ID"
+
+xcodebuild -scheme Hatter \
+    -destination 'generic/platform=iOS' \
+    -configuration Debug \
+    -allowProvisioningUpdates \
+    ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    CODE_SIGN_STYLE=Automatic
+
+# Install on connected device
+APP_PATH=$(ls -d "$workdir"/build/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null \
+  || ls -d DerivedData/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null)
+if [ -n "$APP_PATH" ]; then
+  ios-deploy --bundle "$APP_PATH" || echo "ios-deploy not found, open Xcode to install: open $workdir/Hatter.xcodeproj"
+else
+  echo "Build succeeded. Open Xcode to deploy: open $workdir/Hatter.xcodeproj"
+fi

--- a/setup-ios.sh
+++ b/setup-ios.sh
@@ -18,11 +18,14 @@ chmod -R u+w "$workdir"
 cd "$workdir"
 xcodegen generate
 
-# Auto-discover Apple Development team ID from keychain
+# Auto-discover Apple Development team ID from keychain.
+# The || true keeps set -e/pipefail from killing the script when grep
+# matches nothing, so the empty-TEAM_ID guard below can report it.
 TEAM_ID=$(security find-identity -v -p codesigning \
   | grep "Apple Development" \
   | head -1 \
-  | sed 's/.*(\(.*\)).*/\1/')
+  | sed 's/.*(\(.*\)).*/\1/' \
+  || true)
 [ -z "$TEAM_ID" ] && echo "No Apple Development signing identity found in keychain" && exit 1
 echo "Using team ID: $TEAM_ID"
 
@@ -35,8 +38,11 @@ xcodebuild -scheme Hatter \
     CODE_SIGN_STYLE=Automatic
 
 # Install on connected device
+# The || true keeps set -e from killing the script when the app is in
+# neither location, so the else branch below can point at Xcode.
 APP_PATH=$(ls -d "$workdir"/build/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null \
-  || ls -d DerivedData/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null)
+  || ls -d DerivedData/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null \
+  || true)
 if [ -n "$APP_PATH" ]; then
   ios-deploy --bundle "$APP_PATH" || echo "ios-deploy not found, open Xcode to install: open $workdir/Hatter.xcodeproj"
 else

--- a/setup-ios.sh
+++ b/setup-ios.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Set up kbeacon-ota on a connected iOS device.
-# Requires macOS with Xcode and Nix installed.
+# Prepare an Xcode project for kbeacon-ota on a real iOS device.
+# The user opens the generated project in Xcode and builds/installs from
+# there (device code signing requires the Xcode GUI).
 #
 # Usage:
 #   ./setup-ios.sh
@@ -9,42 +10,20 @@ set -euo pipefail
 
 result=$(nix-build nix/ios-device-app.nix)
 
-# Copy nix output to a writable directory (nix store is read-only)
-workdir=$(mktemp -d)
-cp -r "$result/share/ios/." "$workdir/"
-chmod -R u+w "$workdir"
+# Copy nix output to a stable in-repo directory (nix store is read-only)
+rm -rf ios-project
+cp -r "$result/share/ios/." ios-project/
+chmod -R u+w ios-project
 
-# Generate Xcode project and build
-cd "$workdir"
+# Clear Xcode's DerivedData for Hatter so stale build settings don't persist
+find ~/Library/Developer/Xcode/DerivedData -maxdepth 1 -name 'Hatter-*' -exec rm -rf {} + 2>/dev/null || true
+
+# Generate Xcode project
+cd ios-project
 xcodegen generate
 
-# Auto-discover Apple Development team ID from keychain.
-# The || true keeps set -e/pipefail from killing the script when grep
-# matches nothing, so the empty-TEAM_ID guard below can report it.
-TEAM_ID=$(security find-identity -v -p codesigning \
-  | grep "Apple Development" \
-  | head -1 \
-  | sed 's/.*(\(.*\)).*/\1/' \
-  || true)
-[ -z "$TEAM_ID" ] && echo "No Apple Development signing identity found in keychain" && exit 1
-echo "Using team ID: $TEAM_ID"
-
-xcodebuild -scheme Hatter \
-    -destination 'generic/platform=iOS' \
-    -configuration Debug \
-    -allowProvisioningUpdates \
-    ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
-    DEVELOPMENT_TEAM="$TEAM_ID" \
-    CODE_SIGN_STYLE=Automatic
-
-# Install on connected device
-# The || true keeps set -e from killing the script when the app is in
-# neither location, so the else branch below can point at Xcode.
-APP_PATH=$(ls -d "$workdir"/build/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null \
-  || ls -d DerivedData/Build/Products/Debug-iphoneos/Hatter.app 2>/dev/null \
-  || true)
-if [ -n "$APP_PATH" ]; then
-  ios-deploy --bundle "$APP_PATH" || echo "ios-deploy not found, open Xcode to install: open $workdir/Hatter.xcodeproj"
-else
-  echo "Build succeeded. Open Xcode to deploy: open $workdir/Hatter.xcodeproj"
-fi
+echo ""
+echo "Xcode project ready. Open it with:"
+echo "  open ios-project/Hatter.xcodeproj"
+echo ""
+echo "Then build and install from Xcode (Product → Run)."


### PR DESCRIPTION
## Summary
- Adds setup-ios.sh mirroring prrrrrrrrr's current script: nix-builds the staged Xcode project, copies it to a stable ios-project/ directory, clears stale Hatter DerivedData, runs xcodegen, and tells the user to open Xcode (device code signing requires the Xcode GUI). Device-only on purpose: simulator builds are a CI concern.
- Adds nix/ios-device-app.nix, the device counterpart of the existing simulator-only ios-app.nix.
- Gitignores ios-project/ and documents both entry points in the README.

## Test plan
- [x] `bash -n setup-ios.sh`
- [x] `nix-instantiate nix/ios-device-app.nix` on Linux evaluates to the same darwin-only platform gate as the existing nix/ios-app.nix (these only build on a Mac)
- [ ] On a Mac: `./setup-ios.sh`, then build and run from Xcode on a connected device

🤖 Generated with [Claude Code](https://claude.com/claude-code)